### PR TITLE
feat(budget): agregar modos daily y track

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -82,7 +82,9 @@ export default function DailyBudgetApp() {
         <main className="container px-4 py-6 md:py-10 space-y-8">
           {!isSetup ? (
             <ErrorBoundary>
-              <SetupForm onSetup={setupBudget} />
+              <SetupForm onSetup={({ startAmount, endDate, mode }) => {
+                setupBudget({ startAmount, endDate: endDate!, mode })
+              }} />
             </ErrorBoundary>
           ) : (
             <ErrorBoundary>
@@ -103,6 +105,7 @@ export default function DailyBudgetApp() {
                 <>
                   <ErrorBoundary>
                     <DailyBudgetStatus
+                      budget={budget}
                       dailyAllowance={dailyAllowance}
                       remainingToday={remainingToday}
                       progress={progress}
@@ -164,6 +167,7 @@ export default function DailyBudgetApp() {
                         <ErrorBoundary>
                           <AccountsList
                             accounts={accounts}
+                            budget={budget}
                             onAddAccount={addAccount}
                             onUpdateAccount={updateAccount}
                             onDeleteAccount={deleteAccount}

--- a/components/accounts-list.tsx
+++ b/components/accounts-list.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import { Account, Int, toInt } from '@/types'
+import { Account, Budget, Int, toInt } from '@/types'
 import {
   PlusCircle,
   Wallet,
@@ -77,6 +77,7 @@ const iconMap = {
 
 interface AccountsListProps {
   accounts: Account[]
+  budget: Budget
   onAddAccount: (account: Omit<Account, 'id'>) => void
   onUpdateAccount: (account: Account) => void
   onDeleteAccount: (accountId: string) => boolean
@@ -84,6 +85,7 @@ interface AccountsListProps {
 
 export function AccountsList({
   accounts,
+  budget,
   onAddAccount,
   onUpdateAccount,
   onDeleteAccount
@@ -99,6 +101,12 @@ export function AccountsList({
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const [accountToDelete, setAccountToDelete] = useState<Account | null>(null)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
+
+  // Filter accounts based on mode (hide savings in track mode)
+  const isTrackMode = budget.mode === 'track' || (!budget.mode && !budget.endDate)
+  const filteredAccounts = isTrackMode
+    ? accounts.filter(acc => acc.id !== 'savings')
+    : accounts
 
   const handleAddAccount = (e: React.FormEvent) => {
     e.preventDefault()
@@ -177,7 +185,7 @@ export function AccountsList({
   return (
     <div className="space-y-6">
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {accounts.map((account) => (
+        {filteredAccounts.map((account) => (
           <Card key={account.id}>
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">{account.name}</CardTitle>

--- a/components/config-form.tsx
+++ b/components/config-form.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useState } from "react"
-import { Settings } from "lucide-react"
+import { Settings, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -16,9 +16,10 @@ import { Checkbox } from "./ui/checkbox"
 import { useBudget } from "@/hooks/use-budget"
 
 export function ConfigForm({ budget, onUpdateConfig, onClearData }: {
-  budget: Budget, onClearData: () => void, onUpdateConfig: ({ startAmount, endDate, autoSave }: {
-    startAmount: Int;
-    endDate: Date;
+  budget: Budget, onClearData: () => void, onUpdateConfig: (config: {
+    startAmount?: Int;
+    endDate?: Date | undefined;
+    mode?: 'daily' | 'track';
     autoSave?: boolean
   }) => void,
 }) {
@@ -27,9 +28,11 @@ export function ConfigForm({ budget, onUpdateConfig, onClearData }: {
   const { setLastCheckedDay } = useBudget()
   const [isOpen, setIsOpen] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)
+  const [showDeleteDateConfirm, setShowDeleteDateConfirm] = useState(false)
   const [autoSave, setAutoSave] = useState(budget.autoSave)
   const [startAmount, setStartAmount] = useState(budget.startAmount)
   const [endDate, setEndDate] = useState(budget.endDate)
+  const [mode, setMode] = useState<'daily' | 'track'>(budget.mode || (budget.endDate ? 'daily' : 'track'))
 
   const getYesterday = () => {
     const yesterday = new Date()
@@ -40,7 +43,7 @@ export function ConfigForm({ budget, onUpdateConfig, onClearData }: {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
 
-    if (!startAmount || !endDate) {
+    if (!startAmount || (mode === 'daily' && !endDate)) {
       toast({
         title: t("missingInformation"),
         description: t("missingInformationDescription"),
@@ -60,7 +63,8 @@ export function ConfigForm({ budget, onUpdateConfig, onClearData }: {
 
     onUpdateConfig({
       startAmount: toInt(startAmount) ?? 0 as Int,
-      endDate,
+      endDate: mode === 'daily' ? endDate : undefined,
+      mode,
       autoSave
     })
 
@@ -70,6 +74,18 @@ export function ConfigForm({ budget, onUpdateConfig, onClearData }: {
     toast({
       title: t("configUpdated"),
       description: t("configUpdatedDescription"),
+    })
+  }
+
+  const handleDeleteDate = () => {
+    // Switch to track mode when removing date
+    setMode('track')
+    setEndDate(undefined)
+    setShowDeleteDateConfirm(false)
+    onUpdateConfig({ mode: 'track', endDate: undefined })
+    toast({
+      title: t("modeChanged") || "Mode changed",
+      description: t("trackModeEnabled") || "Track mode enabled",
     })
   }
 
@@ -112,6 +128,27 @@ export function ConfigForm({ budget, onUpdateConfig, onClearData }: {
                 </Button>
               </div>
               <div className="space-y-2">
+                <Label>{t('selectMode') || 'Mode'}</Label>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant={mode === 'daily' ? 'default' : 'outline'}
+                    onClick={() => setMode('daily')}
+                    className="flex-1"
+                  >
+                    {t('dailyMode') || 'Daily Mode'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={mode === 'track' ? 'default' : 'outline'}
+                    onClick={() => setMode('track')}
+                    className="flex-1"
+                  >
+                    {t('trackMode') || 'Track Mode'}
+                  </Button>
+                </div>
+              </div>
+              <div className="space-y-2">
                 <Label htmlFor="startAmount">{t("startingAmount")}</Label>
                 <Input
                   id="startAmount"
@@ -123,16 +160,40 @@ export function ConfigForm({ budget, onUpdateConfig, onClearData }: {
                   required
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="endDate">{t("endDate")}</Label>
-                <DatePicker date={endDate} setDate={setEndDate} className="w-full" />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="autosave">{t("toggleAutoSaving")}</Label>
-                <Checkbox className="ml-2" checked={autoSave} onCheckedChange={() => setAutoSave(!autoSave)} />
-              </div>
+              {mode === 'daily' && (
+                <div className="space-y-2">
+                  <Label htmlFor="endDate">{t("endDate")}</Label>
+                  {endDate ? (
+                    <div className="flex gap-2">
+                      <div className="flex-1">
+                        <DatePicker date={endDate} setDate={setEndDate} className="w-full" />
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={() => setShowDeleteDateConfirm(true)}
+                        title={t("removeDate") || "Remove date"}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      {t("needDateToCalculate") || "Necesito una fecha para poder calcular"}
+                    </p>
+                  )}
+                </div>
+              )}
+              {mode === 'daily' && (
+                <div className="space-y-2">
+                  <Label htmlFor="autosave">{t("toggleAutoSaving")}</Label>
+                  <Checkbox className="ml-2" checked={autoSave} onCheckedChange={() => setAutoSave(!autoSave)} />
+                </div>
+              )}
               <div>
                 <Button
+                  type="button"
                   variant="outline"
                   onClick={() => setLastCheckedDay(getYesterday())}
                   title={t("close")}
@@ -155,8 +216,17 @@ export function ConfigForm({ budget, onUpdateConfig, onClearData }: {
               open={showConfirm}
               onOpenChange={setShowConfirm}
               onConfirm={onClearData}
-              title={t('youSure')} // Confirm action (clear all data?, save changes?)
+              title={t('youSure')}
               description={t("undoable")}
+              confirmText={t("confirm")}
+              cancelText={t("cancel")}
+            />
+            <ConfirmDialog
+              open={showDeleteDateConfirm}
+              onOpenChange={setShowDeleteDateConfirm}
+              onConfirm={handleDeleteDate}
+              title={t('removeEndDate') || "Remove end date?"}
+              description={t('removeEndDateDescription') || "This will switch to track mode."}
               confirmText={t("confirm")}
               cancelText={t("cancel")}
             />

--- a/components/daily-budget-status.tsx
+++ b/components/daily-budget-status.tsx
@@ -4,9 +4,10 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { CircularProgress } from '@/components/circular-progress'
 import { useLanguage } from '@/contexts/language-context'
 import { useCurrency } from '@/contexts/currency-context'
-import type { Account } from '@/types'
+import type { Account, Budget } from '@/types'
 
 interface DailyBudgetStatusProps {
+  budget: Budget
   dailyAllowance: number
   remainingToday: number
   progress: number
@@ -16,6 +17,7 @@ interface DailyBudgetStatusProps {
 
 /**
  * Component to display the daily budget status.
+ * @param budget - The budget object containing mode information.
  * @param dailyAllowance - The daily allowance amount.
  * @param remainingToday - The remaining amount for today.
  * @param progress - The progress percentage.
@@ -24,6 +26,7 @@ interface DailyBudgetStatusProps {
  * @returns JSX element for the daily budget status.
  * @example
  * <DailyBudgetStatus
+ *   budget={budget}
  *   dailyAllowance={100}
  *   remainingToday={50}
  *   progress={50}
@@ -32,6 +35,7 @@ interface DailyBudgetStatusProps {
  * />
  */
 export function DailyBudgetStatus({
+  budget,
   dailyAllowance,
   remainingToday,
   progress,
@@ -41,10 +45,31 @@ export function DailyBudgetStatus({
   const { t } = useLanguage()
   const { formatCurrency } = useCurrency()
 
+  // Determine mode from budget
+  const isTrackMode = budget.mode === 'track' || (!budget.mode && !budget.endDate)
+
   // Find the daily budget account
   const dailyAccount = accounts.find(acc => acc.id === 'daily')
   const totalBudget = dailyAccount ? dailyAccount.balance : 0
 
+  // Track mode: show total balance only
+  if (isTrackMode) {
+    return (
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
+          <div>
+            <CardTitle>{t('totalBalance') || 'Total Balance'}</CardTitle>
+            <CardDescription>{t('trackModeDescription') || 'Track your spending'}</CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-col items-center space-y-6 py-8">
+          <p className="text-5xl font-bold">{formatCurrency(totalBudget)}</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // Daily mode: show full budget status
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between pb-2">

--- a/components/setup-form.tsx
+++ b/components/setup-form.tsx
@@ -11,7 +11,7 @@ import { Int, toInt } from "@/types";
 
 /**
  * Component for setting up the initial budget.
- * @param onSetup - Callback function to handle setup with start amount and end date.
+ * @param onSetup - Callback function to handle setup with start amount, end date, and mode.
  * @returns JSX element for the setup form.
  * @example
  * <SetupForm onSetup={(data) => console.log(data)} />
@@ -19,19 +19,22 @@ import { Int, toInt } from "@/types";
 export function SetupForm({
   onSetup
 }: {
-  onSetup: (data: { startAmount: Int; endDate: Date }) => void
+  onSetup: (data: { startAmount: Int; endDate?: Date; mode: 'daily' | 'track' }) => void
 }) {
   const { t } = useLanguage()
   const [startAmount, setStartAmount] = useState<Int | null>(null)
   const [endDate, setEndDate] = useState<Date | undefined>(undefined)
+  const [mode, setMode] = useState<'daily' | 'track'>('daily')
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (!startAmount || startAmount <= 0 || !endDate) return
+    if (!startAmount || startAmount <= 0) return
+    if (mode === 'daily' && !endDate) return
 
     onSetup({
       startAmount: startAmount,
-      endDate
+      endDate: mode === 'daily' ? endDate : undefined,
+      mode
     })
   }
 
@@ -43,6 +46,27 @@ export function SetupForm({
       </CardHeader>
       <form onSubmit={handleSubmit}>
         <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label>{t('selectMode') || 'Mode'}</Label>
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant={mode === 'daily' ? 'default' : 'outline'}
+                onClick={() => setMode('daily')}
+                className="flex-1"
+              >
+                {t('dailyMode') || 'Daily Mode'}
+              </Button>
+              <Button
+                type="button"
+                variant={mode === 'track' ? 'default' : 'outline'}
+                onClick={() => setMode('track')}
+                className="flex-1"
+              >
+                {t('trackMode') || 'Track Mode'}
+              </Button>
+            </div>
+          </div>
           <div className="space-y-2">
             <Label htmlFor="startAmount">{t('startingAmount')}</Label>
             <Input
@@ -57,14 +81,16 @@ export function SetupForm({
               required
             />
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="endDate">{t('endDate')}</Label>
-            <DatePicker
-              date={endDate}
-              setDate={setEndDate}
-              className="w-full"
-            />
-          </div>
+          {mode === 'daily' && (
+            <div className="space-y-2">
+              <Label htmlFor="endDate">{t('endDate')}</Label>
+              <DatePicker
+                date={endDate}
+                setDate={setEndDate}
+                className="w-full"
+              />
+            </div>
+          )}
         </CardContent>
         <CardFooter>
           <Button

--- a/hooks/use-budget.tsx
+++ b/hooks/use-budget.tsx
@@ -39,6 +39,15 @@ export function useBudget() {
     return startOfDay(new Date())
   }, [])
 
+  // Helper functions to check budget mode
+  const isDailyMode = useCallback(() => {
+    return budget.mode === 'daily' || budget.mode === undefined
+  }, [budget.mode])
+
+  const isTrackMode = useCallback(() => {
+    return budget.mode === 'track'
+  }, [budget.mode])
+
   // Load data from localStorage on initial render
   useEffect(() => {
     const savedData = localStorage.getItem(LOCAL_STORAGE_KEY)
@@ -54,6 +63,11 @@ export function useBudget() {
       }
       if (parsedData.lastCheckedDay) {
         parsedData.lastCheckedDay = new Date(parsedData.lastCheckedDay)
+      }
+
+      // Add default mode if not present (backwards compatibility)
+      if (parsedData.budget && !parsedData.budget.mode) {
+        parsedData.budget.mode = parsedData.budget.endDate ? 'daily' : 'track'
       }
 
       setBudget(parsedData.budget || budget)
@@ -97,6 +111,9 @@ export function useBudget() {
 
   // Calculate daily allowance based on remaining amount and days
   const calculateDailyAllowance = useCallback(() => {
+    // Track mode doesn't have daily allowance
+    if (isTrackMode()) return
+
     if (!budget.endDate) return
 
     const daysRemaining = differenceInDays(budget.endDate, today) + 1
@@ -130,8 +147,8 @@ export function useBudget() {
 
     // If this is the first check or a new day has started
     if (!lastCheckedDay || !isSameDay(today, lastCheckedDay)) {
-      // If there was a previous day, move remaining amount to savings
-      if (lastCheckedDay && remainingToday > 0) {
+      // If there was a previous day, move remaining amount to savings (only in daily mode)
+      if (lastCheckedDay && remainingToday > 0 && isDailyMode() && budget.autoSave) {
         // Add remaining amount to savings and discount from daily
         const updatedAccounts = accounts.map((account) => {
           if (account.id === 'savings') {
@@ -177,10 +194,12 @@ export function useBudget() {
   // Set up initial budget
   const setupBudget = ({
     startAmount,
-    endDate
+    endDate,
+    mode = 'daily'
   }: {
     startAmount: Int
-    endDate: Date
+    endDate?: Date
+    mode?: 'daily' | 'track'
   }) => {
 
     // Create initial budget
@@ -188,16 +207,23 @@ export function useBudget() {
       startAmount,
       startDate: today,
       endDate,
-      autoSave: true
+      autoSave: true,
+      mode
     }
 
     // Update daily account with starting amount
-    const updatedAccounts = accounts.map((account) => {
+    // In track mode, don't include savings account
+    let updatedAccounts = accounts.map((account) => {
       if (account.id === 'daily') {
         return { ...account, balance: startAmount }
       }
       return account
     })
+
+    // Remove savings account in track mode
+    if (mode === 'track') {
+      updatedAccounts = updatedAccounts.filter(acc => acc.id !== 'savings')
+    }
 
     // Record the initial deposit transaction
     const initialTransaction: Transaction = {
@@ -215,12 +241,19 @@ export function useBudget() {
     setLastCheckedDay(startOfDay(today))
     setIsSetup(true)
 
-    // Calculate initial daily allowance
-    const daysRemaining = differenceInDays(endDate, today) + 1
-    const newDailyAllowance = startAmount / daysRemaining
-    setDailyAllowance(newDailyAllowance)
-    setRemainingToday(newDailyAllowance)
-    setProgress(100)
+    // Calculate initial daily allowance only in daily mode with endDate
+    if (mode === 'daily' && endDate) {
+      const daysRemaining = differenceInDays(endDate, today) + 1
+      const newDailyAllowance = startAmount / daysRemaining
+      setDailyAllowance(newDailyAllowance)
+      setRemainingToday(newDailyAllowance)
+      setProgress(100)
+    } else {
+      // Track mode or no endDate
+      setDailyAllowance(0)
+      setRemainingToday(0)
+      setProgress(100)
+    }
   }
 
   // Add a new expense by default
@@ -545,35 +578,59 @@ export function useBudget() {
   // Update budget configuration
   const updateConfig = ({
     startAmount,
-    endDate
+    endDate,
+    mode,
+    autoSave
   }: {
-    startAmount: Int
-    endDate: Date
+    startAmount?: Int
+    endDate?: Date | undefined
+    mode?: 'daily' | 'track'
+    autoSave?: boolean
   }) => {
     // Get current daily account balance
     const dailyAccount = accounts.find((a) => a.id === 'daily')
     const currentBalance = dailyAccount ? dailyAccount.balance : 0
 
-    // Calculate difference to add or subtract
-    const balanceDifference = toInt(startAmount - budget.startAmount) ?? 0 as Int
+    // Calculate difference to add or subtract (if startAmount changed)
+    const balanceDifference = startAmount !== undefined
+      ? toInt(startAmount - budget.startAmount) ?? 0 as Int
+      : 0 as Int
+
+    // Determine new mode: explicit or derive from endDate
+    const newMode = mode ?? (endDate === undefined ? 'track' : 'daily')
 
     // Update budget
     const updatedBudget = {
       ...budget,
-      startAmount,
-      endDate
+      startAmount: startAmount ?? budget.startAmount,
+      endDate,
+      mode: newMode,
+      autoSave: autoSave ?? budget.autoSave
     }
 
-    // Update daily account balance
-    const updatedAccounts = accounts.map((account) => {
-      if (account.id === 'daily') {
-        return { ...account, balance: toInt(currentBalance + balanceDifference) ?? 0 as Int }
-      }
-      return account
-    })
+    // Update accounts based on mode change
+    let updatedAccounts = [...accounts]
 
-    // Create transaction if balance changed
+    // If switching to track mode, remove savings account
+    if (newMode === 'track' && accounts.some(acc => acc.id === 'savings')) {
+      updatedAccounts = updatedAccounts.filter(acc => acc.id !== 'savings')
+    }
+
+    // If switching from track to daily, add savings account if missing
+    if (newMode === 'daily' && !accounts.some(acc => acc.id === 'savings')) {
+      updatedAccounts.push({ id: 'savings', name: 'Savings', type: 'savings', balance: 0 as Int, icon: 'piggybank' })
+    }
+
+    // Update daily account balance if startAmount changed
     if (balanceDifference !== 0) {
+      updatedAccounts = updatedAccounts.map((account) => {
+        if (account.id === 'daily') {
+          return { ...account, balance: toInt(currentBalance + balanceDifference) ?? 0 as Int }
+        }
+        return account
+      })
+
+      // Create transaction
       const transaction: Transaction = {
         id: uuidv4(),
         type: 'transfer',
@@ -588,13 +645,19 @@ export function useBudget() {
     setBudget(updatedBudget)
     setAccounts(updatedAccounts)
 
-    // Recalculate daily allowance
-    const daysRemaining = differenceInDays(endDate, today) + 1
-
-    if (daysRemaining > 0) {
-      const newDailyAllowance = (currentBalance + (balanceDifference ?? 0)) / daysRemaining
-      setDailyAllowance(newDailyAllowance)
-      setRemainingToday(newDailyAllowance)
+    // Recalculate daily allowance only in daily mode with endDate
+    if (newMode === 'daily' && endDate) {
+      const daysRemaining = differenceInDays(endDate, today) + 1
+      if (daysRemaining > 0) {
+        const newDailyAllowance = (currentBalance + balanceDifference) / daysRemaining
+        setDailyAllowance(newDailyAllowance)
+        setRemainingToday(newDailyAllowance)
+        setProgress(100)
+      }
+    } else {
+      // Track mode or no endDate
+      setDailyAllowance(0)
+      setRemainingToday(0)
       setProgress(100)
     }
   }

--- a/tests/unit/setup-form.test.tsx
+++ b/tests/unit/setup-form.test.tsx
@@ -290,7 +290,8 @@ describe('SetupForm', () => {
       // Should call onSetup with correct data
       expect(mockOnSetup).toHaveBeenCalledWith({
         startAmount: 1000, // Should be Int type
-        endDate: new Date(2024, 11, 31)
+        endDate: new Date(2024, 11, 31),
+        mode: 'daily'
       })
     })
 
@@ -314,7 +315,8 @@ describe('SetupForm', () => {
       // Should call onSetup with correct data
       expect(mockOnSetup).toHaveBeenCalledWith({
         startAmount: 1000000, // Should be Int type
-        endDate: new Date(2024, 11, 31)
+        endDate: new Date(2024, 11, 31),
+        mode: 'daily'
       })
     })
   })

--- a/types/index.ts
+++ b/types/index.ts
@@ -67,6 +67,7 @@ export type Budget = {
   startDate: Date | undefined
   endDate: Date | undefined
   autoSave: boolean
+  mode?: 'daily' | 'track'
 }
 
 export type Account = {


### PR DESCRIPTION
Closes #33

## Summary
- Agregar modos daily y track al presupuesto
- Selector de modo en setup inicial y configuración
- Daily mode: daily allowance con fecha límite
- Track mode: solo balance total, sin savings

## Changes

| File | Change |
|------|--------|
|  | Agregar campo mode a Budget |
|  | Lógica según modo |
|  | Selector de modo |
|  | Cambiar modo, editar fecha |
|  | Vista según modo |
|  | Ocultar savings en track |
|  | Pasar budget a componentes |
|  | Tests actualizados |

## Test Plan
- [x] Tests: 44 passed
- [x] Build successful
- [x] Manually tested daily and track modes