### PR TITLE
feat: add income/deposit functionality to accounts

### DIFF
--- a/components/modals/transaction-modal.tsx
+++ b/components/modals/transaction-modal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { FormEvent, useState, useEffect } from 'react'
-import { PlusCircle, Edit } from 'lucide-react'
+import { PlusCircle, Edit, ArrowUpLeft, ArrowDownRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -20,6 +20,7 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useToast } from '@/hooks/use-toast'
 import { useLanguage } from '@/contexts/language-context'
 import { useCurrency } from '@/contexts/currency-context'
@@ -50,7 +51,7 @@ export function TransactionModal({
   const [description, setDescription] = useState('')
   const [date, setDate] = useState(new Date())
   const [account, setAccount] = useState('daily')
-  const [type, setType] = useState<TransactionType>('expense')
+  const [transactionType, setTransactionType] = useState<TransactionType>('expense')
 
   // Reset form when modal opens/closes or transaction changes
   useEffect(() => {
@@ -60,14 +61,14 @@ export function TransactionModal({
       setDescription(transaction.description)
       setDate(new Date(transaction.date))
       setAccount(transaction.account)
-      setType(transaction.type)
+      setTransactionType(transaction.type)
     } else {
       // Adding new transaction
       setAmount(0)
       setDescription('')
       setDate(new Date())
       setAccount('daily')
-      setType('expense')
+      setTransactionType('expense')
     }
   }, [transaction, isOpen])
 
@@ -96,7 +97,7 @@ export function TransactionModal({
       // Update existing transaction
       onUpdateTransaction({
         ...transaction,
-        type,
+        type: transactionType,
         amount: toInt(transaction.amount < 0 ? -amount : amount) as Int, // Preserve sign
         description,
         account,
@@ -110,17 +111,24 @@ export function TransactionModal({
     } else {
       // Add new transaction
       onAddTransaction({
-        type,
+        type: transactionType,
         amount: toInt(amount) as Int,
         description,
         account,
         date
       })
 
-      toast({
-        title: t('expenseAdded'),
-        description: t('expenseAddedDescription', { amount: formatCurrency(amount) })
-      })
+      if (transactionType === 'income') {
+        toast({
+          title: t('incomeAdded'),
+          description: t('incomeAddedDescription', { amount: formatCurrency(amount) })
+        })
+      } else {
+        toast({
+          title: t('expenseAdded'),
+          description: t('expenseAddedDescription', { amount: formatCurrency(amount) })
+        })
+      }
     }
 
     onClose()
@@ -135,13 +143,49 @@ export function TransactionModal({
     >
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
-          <DialogTitle>
-            {isEditing ? t('editTransaction') : t('addExpense')}
+          <DialogTitle className="flex items-center gap-2">
+            {isEditing ? (
+              t('editTransaction')
+            ) : transactionType === 'income' ? (
+              <>
+                <ArrowUpLeft className="h-5 w-5 text-green-600 dark:text-green-500" />
+                {t('addIncome')}
+              </>
+            ) : (
+              <>
+                <ArrowDownRight className="h-5 w-5 text-red-600 dark:text-red-500" />
+                {t('addExpense')}
+              </>
+            )}
           </DialogTitle>
           <DialogDescription>
-            {isEditing ? t('editTransactionDescription') : t('addExpenseDescription')}
+            {isEditing ? t('editTransactionDescription') : transactionType === 'income' ? t('addIncomeDescription') : t('addExpenseDescription')}
           </DialogDescription>
         </DialogHeader>
+        {!isEditing && (
+          <Tabs 
+            value={transactionType} 
+            onValueChange={(v) => setTransactionType(v as TransactionType)}
+            className="w-full"
+          >
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger 
+                value="expense"
+                className="flex items-center gap-2 data-[state=active]:text-red-600 data-[state=active]:dark:text-red-500"
+              >
+                <ArrowDownRight className="h-4 w-4" />
+                {t('expenses')}
+              </TabsTrigger>
+              <TabsTrigger 
+                value="income"
+                className="flex items-center gap-2 data-[state=active]:text-green-600 data-[state=active]:dark:text-green-500"
+              >
+                <ArrowUpLeft className="h-4 w-4" />
+                {t('income')}
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+        )}
         <form
           onSubmit={handleSubmit}
           className="space-y-4 pt-4"
@@ -157,7 +201,7 @@ export function TransactionModal({
               onChange={(e) => setAmount(e.target.valueAsNumber || 0)}
               required
             />
-            {!isEditing && amount > remainingToday && (
+            {!isEditing && transactionType === 'expense' && amount > remainingToday && (
               <p className="text-sm text-yellow-500 dark:text-yellow-400">
                 {t('expenseExceedsWarning')}
               </p>
@@ -168,7 +212,7 @@ export function TransactionModal({
             <Label htmlFor="description">{t('description')}</Label>
             <Textarea
               id="description"
-              placeholder={t('whatExpenseFor')}
+              placeholder={transactionType === 'income' ? t('whatIncomeFor') : t('whatExpenseFor')}
               value={description}
               onChange={(e) => setDescription(e.target.value)}
             />
@@ -214,15 +258,23 @@ export function TransactionModal({
             >
               {t('cancel')}
             </Button>
-            <Button type="submit">
+            <Button 
+              type="submit"
+              variant={isEditing ? 'default' : transactionType === 'income' ? 'income' : 'destructive'}
+            >
               {isEditing ? (
                 <>
                   <Edit className="mr-2 h-4 w-4" />
                   {t('updateTransaction')}
                 </>
+              ) : transactionType === 'income' ? (
+                <>
+                  <ArrowUpLeft className="mr-2 h-4 w-4" />
+                  {t('addIncome')}
+                </>
               ) : (
                 <>
-                  <PlusCircle className="mr-2 h-4 w-4" />
+                  <ArrowDownRight className="mr-2 h-4 w-4" />
                   {t('addExpense')}
                 </>
               )}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -18,6 +18,7 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        income: "bg-green-600 text-white hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-600",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -47,6 +47,7 @@ export const translations = {
     transfer: 'Transfer',
     accounts: 'Accounts',
     history: 'History',
+    income: 'Income',
 
     // Transaction Form
     addIncome: 'Add Income',
@@ -67,6 +68,7 @@ export const translations = {
     recentExpensesDescription: 'Your latest recorded expenses',
     noExpenses: 'No expenses yet',
     transactionType: 'Transaction Type',
+    whatIncomeFor: 'What is this income for?',
 
     // Transfer Form
     transferFunds: 'Transfer Funds',
@@ -113,6 +115,8 @@ export const translations = {
     // Toasts
     expenseAdded: 'Expense Added',
     expenseAddedDescription: '{amount} was added.',
+    incomeAdded: 'Income Added',
+    incomeAddedDescription: '{amount} was added.',
     transactionUpdated: 'Transaction Updated',
     transactionUpdatedDescription: '{amount} was updated.',
     invalidAmount: 'Invalid Amount',
@@ -176,6 +180,7 @@ export const translations = {
     transfer: 'Transferencias',
     accounts: 'Cuentas',
     history: 'Historial',
+    income: 'Ingresos',
 
     // Transaction Form
     addIncome: 'Agregar ingreso',
@@ -191,6 +196,7 @@ export const translations = {
     selectAccount: 'Selecciona una cuenta',
     expenseExceedsWarning: 'Este gasto excede tu presupuesto diario.',
     whatExpenseFor: '¿Para qué es este gasto?',
+    whatIncomeFor: '¿Para qué es este ingreso?',
     unnamedExpense: 'Gasto sin nombre',
     recentExpenses: 'Gastos recientes',
     recentExpensesDescription: 'Tus gastos más recientes',
@@ -242,6 +248,8 @@ export const translations = {
     // Toasts
     expenseAdded: 'Gasto registrado',
     expenseAddedDescription: '{amount} fue agregado.',
+    incomeAdded: 'Ingreso registrado',
+    incomeAddedDescription: '{amount} fue registrado.',
     transactionUpdated: 'Transacción actualizada',
     transactionUpdatedDescription: '{amount} fue actualizado.',
     invalidAmount: 'Monto inválido',

--- a/hooks/use-budget.tsx
+++ b/hooks/use-budget.tsx
@@ -340,6 +340,40 @@ export function useBudget() {
 
       setAccounts(updatedAccounts)
     }
+
+    if (type === 'income') {
+      // Create transaction record with POSITIVE amount
+      const transaction = {
+        id: uuidv4(),
+        type,
+        date,
+        amount: toInt(amount) ?? 0 as Int, // Positive for income
+        description,
+        account
+      }
+
+      // Update account balance by adding the income amount
+      const updatedAccounts = accounts.map((acc) => {
+        if (acc.id === account) {
+          return { ...acc, balance: toInt(acc.balance + amount) ?? 0 as Int }
+        }
+        return acc
+      })
+
+      // If daily account in budget mode, also update remainingToday and progress
+      if (account === 'daily' && budget.endDate) {
+        const daysRemaining = differenceInDays(budget.endDate, today) + 1
+        if (daysRemaining > 0) {
+          const newDailyAllowance = (accounts.find(a => a.id === 'daily')!.balance + amount) / daysRemaining
+          setDailyAllowance(newDailyAllowance)
+          setRemainingToday(newDailyAllowance)
+          setProgress(100)
+        }
+      }
+
+      setAccounts(updatedAccounts)
+      setTransactions([transaction, ...transactions])
+    }
   }
 
   // Remove an existing transaction


### PR DESCRIPTION
## Summary

- Adds income/deposit functionality to allow users to add money to accounts
- Implements income tab in transaction modal with expense/income selection
- Recalculates daily allowance when income is added to daily account
- Adds required translations for income flow (EN/ES)

## Changes

| File | Change |
|------|--------|
| `hooks/use-budget.tsx` | Add income handling in addTransaction function |
| `components/modals/transaction-modal.tsx` | Add income/expense tabs UI |
| `components/ui/button.tsx` | Add green income variant |
| `contexts/language-context.tsx` | Add missing translations |

## Test Plan

- [x] Unit tests pass: `npx vitest run` (44 tests)
- [x] Build passes: `npm run build`
- [x] Manually tested income flow in UI
- [x] Verified daily allowance recalculates correctly

Closes #35