### PR TITLE
feat(transactions): add adjustment tracking and delete with choice modal

### DIFF
--- a/components/modals/delete-transaction-modal.tsx
+++ b/components/modals/delete-transaction-modal.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { Dialog, DialogContent, DialogTitle, DialogDescription, DialogHeader } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { useLanguage } from '@/contexts/language-context'
+import { useCurrency } from '@/contexts/currency-context'
+import type { Transaction } from '@/types'
+
+interface DeleteTransactionModalProps {
+  isOpen: boolean
+  onClose: () => void
+  transaction: Transaction | null
+  onDelete: (refund: boolean) => void
+  accountName?: string
+}
+
+export function DeleteTransactionModal({
+  isOpen,
+  onClose,
+  transaction,
+  onDelete,
+  accountName,
+}: DeleteTransactionModalProps) {
+  const { t } = useLanguage()
+  const { formatCurrency } = useCurrency()
+
+  if (!transaction) return null
+
+  const handleDelete = (refund: boolean) => {
+    onDelete(refund)
+    onClose()
+  }
+
+  const displayAccount = accountName || transaction.account
+  const displayAmount = Math.abs(transaction.amount)
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose()
+      }}
+    >
+      <DialogContent className="sm:max-w-[400px] border-white/20 dark:border-white/10 bg-white/5 dark:bg-black/20 backdrop-blur-sm">
+        <DialogHeader className="sr-only">
+          <DialogTitle>{t('deleteTransactionTitle')}</DialogTitle>
+        </DialogHeader>
+        <DialogDescription className="text-center">
+          {t('deleteTransactionQuestion')}
+        </DialogDescription>
+
+        <div className="rounded-lg border border-white/10 p-4 space-y-1">
+          <p className="font-medium text-sm">{transaction.description}</p>
+          <p className="text-lg font-semibold">{formatCurrency(displayAmount)}</p>
+          <p className="text-sm text-muted-foreground">{displayAccount}</p>
+        </div>
+
+        <div className="flex gap-2 pt-2">
+          <Button
+            variant="outline"
+            className="flex-1 hover:shadow-inner"
+            onClick={() => handleDelete(true)}
+          >
+            {t('deleteAndRefund')}
+          </Button>
+          <Button
+            variant="outline"
+            className="flex-1 hover:shadow-inner"
+            onClick={() => handleDelete(false)}
+          >
+            {t('deleteKeepBalance')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/transaction-history.tsx
+++ b/components/transaction-history.tsx
@@ -1,21 +1,35 @@
 "use client"
 
+import { useState } from "react"
 import { format } from "date-fns"
 import { es } from "date-fns/locale/es"
+import { Trash2 } from "lucide-react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { Button } from "@/components/ui/button"
 import { useLanguage } from "@/contexts/language-context"
 import { useCurrency } from "@/contexts/currency-context"
 import { useBudget } from "@/hooks/use-budget"
 import { Transaction } from '@/types'
+import { DeleteTransactionModal } from "@/components/modals/delete-transaction-modal"
 
 export function TransactionHistory({ transactions }: { transactions: Transaction[] }) {
   const { t, language } = useLanguage()
   const { formatCurrency } = useCurrency()
-  const { accounts } = useBudget()
+  const { accounts, removeTransaction } = useBudget()
+  const [deleteTarget, setDeleteTarget] = useState<{
+    transaction: Transaction
+    accountName: string
+  } | null>(null)
 
   // Set locale based on language
   const locale = language === "es" ? es : undefined
+
+  const handleDelete = (refund: boolean) => {
+    if (!deleteTarget) return
+    removeTransaction(deleteTarget.transaction.id, refund)
+    setDeleteTarget(null)
+  }
 
   return (
     <Card>
@@ -34,6 +48,7 @@ export function TransactionHistory({ transactions }: { transactions: Transaction
                 <TableHead>{t("description")}</TableHead>
                 <TableHead>{t("account")}</TableHead>
                 <TableHead className="text-right">{t("amount")}</TableHead>
+                <TableHead className="w-10"></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -47,6 +62,21 @@ export function TransactionHistory({ transactions }: { transactions: Transaction
                     <TableCell className={`text-right ${transaction.amount < 0 ? "text-red-500" : ""}`}>
                       {formatCurrency(Math.abs(transaction.amount))}
                     </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                        onClick={() =>
+                          setDeleteTarget({
+                            transaction,
+                            accountName: account?.name || t("unknownAccount")
+                          })
+                        }
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </TableCell>
                   </TableRow>
                 )
               })}
@@ -54,6 +84,14 @@ export function TransactionHistory({ transactions }: { transactions: Transaction
           </Table>
         )}
       </CardContent>
+
+      <DeleteTransactionModal
+        isOpen={!!deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        transaction={deleteTarget?.transaction ?? null}
+        onDelete={handleDelete}
+        accountName={deleteTarget?.accountName}
+      />
     </Card>
   )
 }

--- a/components/transactions-list.tsx
+++ b/components/transactions-list.tsx
@@ -32,8 +32,8 @@ export function TransactionList({
   // Set locale based on language
   const locale = language === 'es' ? es : undefined
 
-  // Filter only expense transactions (negative amounts)
-  const expenses = transactions.filter((transaction) => transaction.amount < 0)
+  // Filter only expense transactions (by type)
+  const expenses = transactions.filter((transaction) => transaction.type === 'expense')
 
   // Function to get a short name from description
   const getShortName = (description: string) => {

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -70,6 +70,15 @@ export const translations = {
     transactionType: 'Transaction Type',
     whatIncomeFor: 'What is this income for?',
 
+    // Delete Transaction
+    adjustmentDescription: 'Balance adjustment',
+    deleteTransactionTitle: 'Delete transaction',
+    deleteTransactionQuestion: 'What should happen to the balance?',
+    deleteAndRefund: 'Delete and refund',
+    deleteAndRefundDescription: 'Removes the transaction and returns the money to the account',
+    deleteKeepBalance: 'Delete, keep balance',
+    deleteKeepBalanceDescription: 'Removes the transaction without changing the balance',
+
     // Transfer Form
     transferFunds: 'Transfer Funds',
     transferDescription: 'Move money between your accounts',
@@ -202,6 +211,15 @@ export const translations = {
     recentExpensesDescription: 'Tus gastos más recientes',
     noExpenses: 'Aún no hay gastos',
     transactionType: 'Tipo de transacción',
+
+    // Delete Transaction
+    adjustmentDescription: 'Ajuste de saldo',
+    deleteTransactionTitle: 'Eliminar transacción',
+    deleteTransactionQuestion: '¿Qué hacer con el saldo?',
+    deleteAndRefund: 'Eliminar y devolver',
+    deleteAndRefundDescription: 'Elimina la transacción y devuelve el dinero a la cuenta',
+    deleteKeepBalance: 'Eliminar, mantener saldo',
+    deleteKeepBalanceDescription: 'Elimina la transacción sin modificar el saldo',
 
     // Transfer Form
     transferFunds: 'Transferir fondos',

--- a/hooks/use-budget.tsx
+++ b/hooks/use-budget.tsx
@@ -379,27 +379,29 @@ export function useBudget() {
   }
 
   // Remove an existing transaction
-  const removeTransaction = (transactionId: string) => {
+  const removeTransaction = (transactionId: string, refund: boolean = true) => {
     // Get transaction object
     const transaction = transactions.find((t) => t.id === transactionId)
     if (transaction) {
-      const { account, amount } = transaction
-      // Update accounts based on expense logic
-      let updatedAccounts = [...accounts]
+      if (refund) {
+        const { account, amount } = transaction
+        // Update accounts based on expense logic
+        let updatedAccounts = [...accounts]
 
-      updatedAccounts = accounts.map((acc) => {
-        if (acc.id === account) {
-          return { ...acc, balance: toInt(acc.balance + Math.abs(amount)) ?? 0 as Int }
+        updatedAccounts = accounts.map((acc) => {
+          if (acc.id === account) {
+            return { ...acc, balance: toInt(acc.balance - amount) ?? 0 as Int }
+          }
+          return acc
+        })
+
+        if (isToday(transaction.date)) {
+          setRemainingToday(remainingToday - amount)
+          setProgress(((remainingToday - amount) / dailyAllowance) * 100)
         }
-        return acc
-      })
-
-      if (isToday(transaction.date)) {
-        setRemainingToday(remainingToday + Math.abs(amount))
-        setProgress(((remainingToday + Math.abs(amount)) / dailyAllowance) * 100)
+        setAccounts(updatedAccounts)
       }
       setTransactions(transactions.filter((transaction) => transaction.id !== transactionId))
-      setAccounts(updatedAccounts)
     }
   }
 
@@ -486,6 +488,9 @@ export function useBudget() {
 
   // Update an existing account
   const updateAccount = (updatedAccount: Account) => {
+    // Find the old account before updating
+    const oldAccount = accounts.find((a) => a.id === updatedAccount.id)
+
     const updatedAccounts = accounts.map((account) => {
       if (account.id === updatedAccount.id) {
         return { ...account, ...updatedAccount }
@@ -494,6 +499,22 @@ export function useBudget() {
     })
 
     setAccounts(updatedAccounts)
+
+    // Create adjustment transaction if the balance changed
+    if (oldAccount && oldAccount.balance !== updatedAccount.balance) {
+      const delta = toInt(updatedAccount.balance - oldAccount.balance) ?? 0 as Int
+      if (delta !== 0) {
+        const adjustmentTransaction: Transaction = {
+          id: uuidv4(),
+          type: 'adjustment',
+          amount: delta,
+          description: 'Balance adjustment',
+          account: updatedAccount.id,
+          date: today
+        }
+        setTransactions([adjustmentTransaction, ...transactions])
+      }
+    }
   }
 
   // Delete an account

--- a/tests/unit/delete-transaction-modal.test.tsx
+++ b/tests/unit/delete-transaction-modal.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { DeleteTransactionModal } from '@/components/modals/delete-transaction-modal'
+import { LanguageProvider } from '@/contexts/language-context'
+import { CurrencyProvider } from '@/contexts/currency-context'
+import { Transaction, Int } from '@/types'
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <LanguageProvider>
+      <CurrencyProvider>{ui}</CurrencyProvider>
+    </LanguageProvider>
+  )
+}
+
+describe('DeleteTransactionModal', () => {
+  const baseTransaction: Transaction = {
+    id: '1',
+    type: 'expense',
+    amount: -1500 as Int,
+    description: 'Groceries',
+    account: 'daily',
+    date: new Date('2024-01-15')
+  }
+
+  it('renders when open with transaction details', () => {
+    renderWithProviders(
+      <DeleteTransactionModal
+        isOpen={true}
+        onClose={vi.fn()}
+        transaction={baseTransaction}
+        onDelete={vi.fn()}
+        accountName="Daily Budget"
+      />
+    )
+
+    expect(screen.getByText('What should happen to the balance?')).toBeInTheDocument()
+    expect(screen.getByText('Groceries')).toBeInTheDocument()
+    expect(screen.getByText('Daily Budget')).toBeInTheDocument()
+    expect(screen.getByText('Delete and refund')).toBeInTheDocument()
+    expect(screen.getByText('Delete, keep balance')).toBeInTheDocument()
+  })
+
+  it('calls onDelete(true) when "Delete and refund" is clicked', () => {
+    const onDelete = vi.fn()
+    const onClose = vi.fn()
+
+    renderWithProviders(
+      <DeleteTransactionModal
+        isOpen={true}
+        onClose={onClose}
+        transaction={baseTransaction}
+        onDelete={onDelete}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Delete and refund'))
+    expect(onDelete).toHaveBeenCalledWith(true)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onDelete(false) when "Delete, keep balance" is clicked', () => {
+    const onDelete = vi.fn()
+    const onClose = vi.fn()
+
+    renderWithProviders(
+      <DeleteTransactionModal
+        isOpen={true}
+        onClose={onClose}
+        transaction={baseTransaction}
+        onDelete={onDelete}
+      />
+    )
+
+    fireEvent.click(screen.getByText('Delete, keep balance'))
+    expect(onDelete).toHaveBeenCalledWith(false)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('does not render when transaction is null', () => {
+    const { container } = renderWithProviders(
+      <DeleteTransactionModal
+        isOpen={true}
+        onClose={vi.fn()}
+        transaction={null}
+        onDelete={vi.fn()}
+      />
+    )
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn()
+
+    renderWithProviders(
+      <DeleteTransactionModal
+        isOpen={true}
+        onClose={onClose}
+        transaction={baseTransaction}
+        onDelete={vi.fn()}
+      />
+    )
+
+    const closeButton = screen.getByRole('button', { name: /close/i })
+    fireEvent.click(closeButton)
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/transactions-list.test.tsx
+++ b/tests/unit/transactions-list.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { TransactionList } from '@/components/transactions-list'
+import { LanguageProvider } from '@/contexts/language-context'
+import { CurrencyProvider } from '@/contexts/currency-context'
+import { Transaction, Int } from '@/types'
+
+// Mock useBudget to provide accounts without localStorage side effects
+vi.mock('@/hooks/use-budget', () => ({
+  useBudget: () => ({
+    accounts: [
+      { id: 'daily', name: 'Daily Budget', type: 'daily', balance: 1000 as Int, icon: 'wallet' },
+      { id: 'savings', name: 'Savings', type: 'savings', balance: 500 as Int, icon: 'piggybank' }
+    ]
+  })
+}))
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <LanguageProvider>
+      <CurrencyProvider>{ui}</CurrencyProvider>
+    </LanguageProvider>
+  )
+}
+
+describe('TransactionList', () => {
+  const defaultAccounts = [
+    { id: 'daily', name: 'Daily Budget', type: 'daily', balance: 1000 as Int, icon: 'wallet' }
+  ]
+
+  it('renders expense transactions', () => {
+    const transactions: Transaction[] = [
+      {
+        id: '1',
+        type: 'expense',
+        amount: -1500 as Int,
+        description: 'Groceries',
+        account: 'daily',
+        date: new Date('2024-01-15')
+      }
+    ]
+
+    renderWithProviders(
+      <TransactionList
+        transactions={transactions}
+        onDelete={vi.fn()}
+        openTransactionModal={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Groceries')).toBeInTheDocument()
+  })
+
+  it('excludes adjustment transactions from the expenses list', () => {
+    const expenseTransaction: Transaction = {
+      id: 'exp-1',
+      type: 'expense',
+      amount: -1000 as Int,
+      description: 'Groceries',
+      account: 'daily',
+      date: new Date('2024-01-15')
+    }
+
+    const adjustmentTransaction: Transaction = {
+      id: 'adj-1',
+      type: 'adjustment',
+      amount: -500 as Int,
+      description: 'Balance adjustment',
+      account: 'daily',
+      date: new Date('2024-01-15')
+    }
+
+    renderWithProviders(
+      <TransactionList
+        transactions={[expenseTransaction, adjustmentTransaction]}
+        onDelete={vi.fn()}
+        openTransactionModal={vi.fn()}
+      />
+    )
+
+    // The expense transaction should be visible
+    expect(screen.getByText('Groceries')).toBeInTheDocument()
+
+    // The adjustment transaction should NOT be visible in the expenses list
+    expect(screen.queryByText('Balance adjustment')).not.toBeInTheDocument()
+  })
+
+  it('excludes income transactions from the expenses list', () => {
+    const incomeTransaction: Transaction = {
+      id: 'inc-1',
+      type: 'income',
+      amount: 5000 as Int,
+      description: 'Paycheck',
+      account: 'daily',
+      date: new Date('2024-01-15')
+    }
+
+    const expenseTransaction: Transaction = {
+      id: 'exp-1',
+      type: 'expense',
+      amount: -2000 as Int,
+      description: 'Dinner',
+      account: 'daily',
+      date: new Date('2024-01-15')
+    }
+
+    renderWithProviders(
+      <TransactionList
+        transactions={[incomeTransaction, expenseTransaction]}
+        onDelete={vi.fn()}
+        openTransactionModal={vi.fn()}
+      />
+    )
+
+    // The expense transaction should be visible
+    expect(screen.getByText('Dinner')).toBeInTheDocument()
+
+    // The income transaction should NOT be visible
+    expect(screen.queryByText('Paycheck')).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when there are no expenses', () => {
+    const transactions: Transaction[] = [
+      {
+        id: 'adj-1',
+        type: 'adjustment',
+        amount: -500 as Int,
+        description: 'Balance adjustment',
+        account: 'daily',
+        date: new Date('2024-01-15')
+      }
+    ]
+
+    renderWithProviders(
+      <TransactionList
+        transactions={transactions}
+        onDelete={vi.fn()}
+        openTransactionModal={vi.fn()}
+      />
+    )
+
+    // With only an adjustment transaction (not an expense), the empty state should show
+    expect(screen.getByText('No expenses yet')).toBeInTheDocument()
+  })
+})

--- a/tests/unit/use-budget.test.tsx
+++ b/tests/unit/use-budget.test.tsx
@@ -21,15 +21,21 @@ vi.mock('date-fns', () => ({
   isToday: vi.fn((date) => new Date().toDateString() === date.toDateString()),
 }))
 
-// Mock uuid
+// Mock uuid with unique IDs
+let uuidCounter = 0
 vi.mock('uuid', () => ({
-  v4: vi.fn(() => 'mock-uuid'),
+  v4: vi.fn(() => {
+    const id = `mock-uuid-${uuidCounter}`
+    uuidCounter++
+    return id
+  }),
 }))
 
 describe('useBudget hook', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorageMock.getItem.mockReturnValue(null)
+    uuidCounter = 0
   })
 
   it('initializes with default accounts and empty transactions', () => {
@@ -219,5 +225,234 @@ describe('useBudget hook', () => {
 
     // Account should still exist
     expect(result.current.accounts.find(a => a.id === 'daily')).toBeDefined()
+  })
+
+  describe('T-2: updateAccount creates adjustment transaction', () => {
+    it('creates adjustment transaction when balance increases', () => {
+      const { result } = renderHook(() => useBudget())
+
+      act(() => {
+        result.current.setupBudget({
+          startAmount: 1000 as any,
+          endDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+        })
+      })
+
+      const dailyAccount = result.current.accounts.find(a => a.id === 'daily')!
+
+      act(() => {
+        result.current.updateAccount({ ...dailyAccount, balance: 1500 as any })
+      })
+
+      // Initial deposit + adjustment transaction
+      expect(result.current.transactions).toHaveLength(2)
+
+      const adjustmentTx = result.current.transactions[0]
+      expect(adjustmentTx.type).toBe('adjustment')
+      expect(adjustmentTx.amount).toBe(500) // 1500 - 1000
+      expect(adjustmentTx.description).toBe('Balance adjustment')
+      expect(adjustmentTx.account).toBe('daily')
+    })
+
+    it('creates adjustment transaction when balance decreases', () => {
+      const { result } = renderHook(() => useBudget())
+
+      act(() => {
+        result.current.setupBudget({
+          startAmount: 1000 as any,
+          endDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+        })
+      })
+
+      const dailyAccount = result.current.accounts.find(a => a.id === 'daily')!
+
+      act(() => {
+        result.current.updateAccount({ ...dailyAccount, balance: 300 as any })
+      })
+
+      expect(result.current.transactions).toHaveLength(2)
+
+      const adjustmentTx = result.current.transactions[0]
+      expect(adjustmentTx.type).toBe('adjustment')
+      expect(adjustmentTx.amount).toBe(-700) // 300 - 1000 = -700
+    })
+
+    it('does not create adjustment transaction when balance unchanged', () => {
+      const { result } = renderHook(() => useBudget())
+
+      act(() => {
+        result.current.setupBudget({
+          startAmount: 1000 as any,
+          endDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+        })
+      })
+
+      const dailyAccount = result.current.accounts.find(a => a.id === 'daily')!
+
+      act(() => {
+        result.current.updateAccount({ ...dailyAccount, balance: 1000 as any })
+      })
+
+      // Still only the initial deposit
+      expect(result.current.transactions).toHaveLength(1)
+    })
+  })
+
+  describe('T-5: removeTransaction with refund param', () => {
+    it('refunds balance when refund=true (default)', () => {
+      const { result } = renderHook(() => useBudget())
+
+      act(() => {
+        result.current.setupBudget({
+          startAmount: 1000 as any,
+          endDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+        })
+      })
+
+      act(() => {
+        result.current.addTransaction({
+          type: 'expense',
+          amount: 200,
+          description: 'Test expense',
+          account: 'daily'
+        })
+      })
+
+      const dailyAccount = result.current.accounts.find(a => a.id === 'daily')!
+      expect(dailyAccount.balance).toBe(800) // 1000 - 200
+
+      // addTransaction inserts at the beginning, so expense is at index 0
+      const expenseTx = result.current.transactions[0]
+      expect(expenseTx.type).toBe('expense')
+
+      act(() => {
+        result.current.removeTransaction(expenseTx.id)
+      })
+
+      const dailyAccountAfter = result.current.accounts.find(a => a.id === 'daily')!
+      expect(dailyAccountAfter.balance).toBe(1000) // balance restored
+      expect(result.current.transactions).toHaveLength(1) // only initial deposit
+    })
+
+    it('does not refund balance when refund=false', () => {
+      const { result } = renderHook(() => useBudget())
+
+      act(() => {
+        result.current.setupBudget({
+          startAmount: 1000 as any,
+          endDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+        })
+      })
+
+      act(() => {
+        result.current.addTransaction({
+          type: 'expense',
+          amount: 200,
+          description: 'Test expense',
+          account: 'daily'
+        })
+      })
+
+      const dailyAccount = result.current.accounts.find(a => a.id === 'daily')!
+      expect(dailyAccount.balance).toBe(800)
+
+      // addTransaction inserts at the beginning, so expense is at index 0
+      const expenseTx = result.current.transactions[0]
+      expect(expenseTx.type).toBe('expense')
+
+      act(() => {
+        result.current.removeTransaction(expenseTx.id, false)
+      })
+
+      const dailyAccountAfter = result.current.accounts.find(a => a.id === 'daily')!
+      expect(dailyAccountAfter.balance).toBe(800) // balance NOT restored
+      expect(result.current.transactions).toHaveLength(1) // transaction removed
+    })
+
+    it('deleting positive adjustment with refund=true reverses the effect (Scenario 3e)', () => {
+      const { result } = renderHook(() => useBudget())
+
+      act(() => {
+        result.current.setupBudget({
+          startAmount: 1000 as any,
+          endDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+        })
+      })
+
+      const daily = result.current.accounts.find(a => a.id === 'daily')!
+      expect(daily.balance).toBe(1000)
+
+      // Increase balance to 1500 → creates +500 adjustment
+      act(() => {
+        result.current.updateAccount({ ...daily, balance: 1500 as any })
+      })
+
+      expect(result.current.accounts.find(a => a.id === 'daily')!.balance).toBe(1500)
+
+      const adjustmentTx = result.current.transactions[0]
+      expect(adjustmentTx.type).toBe('adjustment')
+      expect(adjustmentTx.amount).toBe(500)
+
+      // Delete adjustment with refund → balance should return to 1000
+      act(() => {
+        result.current.removeTransaction(adjustmentTx.id, true)
+      })
+
+      expect(result.current.accounts.find(a => a.id === 'daily')!.balance).toBe(1000)
+    })
+
+    it('deleting negative adjustment with refund=true reverses the effect', () => {
+      const { result } = renderHook(() => useBudget())
+
+      act(() => {
+        result.current.setupBudget({
+          startAmount: 1000 as any,
+          endDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+        })
+      })
+
+      const daily = result.current.accounts.find(a => a.id === 'daily')!
+
+      // Decrease balance to 300 → creates -700 adjustment
+      act(() => {
+        result.current.updateAccount({ ...daily, balance: 300 as any })
+      })
+
+      expect(result.current.accounts.find(a => a.id === 'daily')!.balance).toBe(300)
+
+      const adjustmentTx = result.current.transactions[0]
+      expect(adjustmentTx.type).toBe('adjustment')
+      expect(adjustmentTx.amount).toBe(-700)
+
+      // Delete adjustment with refund → balance returns to 1000
+      act(() => {
+        result.current.removeTransaction(adjustmentTx.id, true)
+      })
+
+      expect(result.current.accounts.find(a => a.id === 'daily')!.balance).toBe(1000)
+    })
+
+    it('safely handles non-existent transaction id', () => {
+      const { result } = renderHook(() => useBudget())
+
+      act(() => {
+        result.current.setupBudget({
+          startAmount: 1000 as any,
+          endDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+        })
+      })
+
+      expect(() => {
+        act(() => {
+          result.current.removeTransaction('non-existent-id')
+        })
+      }).not.toThrow()
+
+      expect(() => {
+        act(() => {
+          result.current.removeTransaction('non-existent-id', false)
+        })
+      }).not.toThrow()
+    })
   })
 })

--- a/types/index.ts
+++ b/types/index.ts
@@ -60,7 +60,7 @@ export type Transaction = {
   date: Date
 }
 
-export type TransactionType = 'expense' | 'transfer' | 'income'
+export type TransactionType = 'expense' | 'transfer' | 'income' | 'adjustment'
 
 export type Budget = {
   startAmount: Int


### PR DESCRIPTION
## Summary
- **Adjustment transactions**: Editing an account balance now creates an `adjustment` transaction in the history
- **Delete with choice**: New modal with two options when deleting — refund the money or keep the balance
- **Bug fix**: `removeTransaction()` now correctly reverses any transaction type (not just expenses)

## Changes
| File | Change |
|------|--------|
| `types/index.ts` | +'adjustment' to TransactionType |
| `hooks/use-budget.tsx` | updateAccount() creates adjustment; removeTransaction() refund param |
| `components/modals/delete-transaction-modal.tsx` | **New** — dark graphite modal with two neutral buttons |
| `components/transaction-history.tsx` | +Trash2 delete button per row |
| `components/transactions-list.tsx` | Filter corrected to type==='expense' |
| `contexts/language-context.tsx` | 7 new translation keys (EN/ES) |
| `tests/unit/use-budget.test.tsx` | +2 tests for adjustment refund |
| `tests/unit/delete-transaction-modal.test.tsx` | **New** — 5 tests for modal |
| `tests/unit/transactions-list.test.tsx` | **New** — 4 tests for expense filter |

## Test Plan
- [x] `pnpm test` — 73 tests passing across 7 files
- [x] `pnpm tsc --noEmit` — 0 type errors
- [x] Manually verified adjustment appears in history on balance edit
- [x] Manually verified delete modal shows with both options