### PR TITLE
feat: cashflow projection with configurable rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the **Daily Budget** project will be documented in this f
 ### Features
 - Add new feature descriptions here
 - `lib/cashflow.ts`: daily balance calculation utility (`calculateDailyBalance`) with `DailyMovement`, `CashflowDayInput`, and `CashflowDayResult` interfaces
+- `components/cashflow-projection`: configurable balance projection (recurring income/expense rules, adjustable time horizon), with interactive chart and substituted-formula display
 
 ### Bug Fixes
 - Fix bug descriptions here

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ CI: Hay un workflow de GitHub Actions en `.github/workflows/tests.yml` que ejecu
 ## 🧩 Utilidades internas
 
 - [`lib/cashflow.ts`](./lib/cashflow.ts) — cálculo de saldo diario a partir de un saldo inicial y una lista de movimientos. Ver documentación completa en [docs/cashflow.md](./docs/cashflow.md).
+- [`components/cashflow-projection`](./components/cashflow-projection/index.tsx) — proyección de saldo configurable (reglas de ingreso/egreso, horizonte de tiempo). Ver [docs/cashflow-projection.md](./docs/cashflow-projection.md).
 
 ---
 

--- a/app/proyeccion/page.tsx
+++ b/app/proyeccion/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CashflowProjection } from "@/components/cashflow-projection";
+
+export default function ProyeccionPage() {
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+      <div className="flex items-center gap-2">
+        <Link href="/">
+          <Button variant="ghost" size="icon" aria-label="Volver">
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        </Link>
+        <h1 className="text-xl font-semibold">Proyección de saldo</h1>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        Configura tus reglas de ingreso y egreso (monto, día de pago, frecuencia) y
+        visualiza cómo evoluciona tu saldo a futuro. Haz click en cualquier punto
+        del gráfico para ver la fórmula aplicada ese día.
+      </p>
+
+      <CashflowProjection />
+    </main>
+  );
+}

--- a/components/cashflow-projection/formula-display.tsx
+++ b/components/cashflow-projection/formula-display.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import type { CashflowDayResult } from "@/lib/cashflow";
+
+interface FormulaDisplayProps {
+  day: CashflowDayResult | undefined;
+  previousBalance: number | undefined;
+}
+
+function formatCLP(value: number): string {
+  return value.toLocaleString("es-CL");
+}
+
+/**
+ * Muestra la fórmula de saldo diario con los valores reales sustituidos
+ * para el día seleccionado:
+ *   saldo(fecha) = saldo_anterior ± |netChange| = balance
+ */
+export function FormulaDisplay({ day, previousBalance }: FormulaDisplayProps) {
+  if (!day) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-sm text-muted-foreground">
+            Selecciona un día en el gráfico para ver la fórmula aplicada.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const prev = previousBalance ?? 0;
+  const operator = day.netChange >= 0 ? "+" : "-";
+
+  return (
+    <Card>
+      <CardContent className="pt-6 space-y-2">
+        <p className="text-sm text-muted-foreground">{day.date}</p>
+        <p className="font-mono text-sm sm:text-base break-words">
+          saldo({day.date}) = {formatCLP(prev)} {operator} {formatCLP(Math.abs(day.netChange))}
+          {" = "}
+          <strong className={day.balance < 0 ? "text-destructive" : ""}>
+            ${formatCLP(day.balance)}
+          </strong>
+        </p>
+
+        {day.movements.length > 0 && (
+          <ul className="text-sm text-muted-foreground list-disc list-inside pt-2">
+            {day.movements.map((m, i) => (
+              <li key={i}>
+                {m.label}: {m.amount >= 0 ? "+" : ""}
+                {formatCLP(m.amount)}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {day.balance < 0 && (
+          <p className="text-sm text-destructive font-medium pt-2">
+            ⚠️ Saldo negativo proyectado este día.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/cashflow-projection/index.tsx
+++ b/components/cashflow-projection/index.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RuleEditor } from "./rule-editor";
+import { ProjectionChart } from "./projection-chart";
+import { FormulaDisplay } from "./formula-display";
+import { useCashflowProjection } from "@/hooks/use-cashflow-projection";
+import type { ProjectionConfig } from "@/types/cashflow-projection";
+
+const DEFAULT_CONFIG: ProjectionConfig = {
+  initialBalance: 30000,
+  startDate: new Date().toISOString().slice(0, 10),
+  horizonDays: 30,
+  rules: [],
+};
+
+interface CashflowProjectionProps {
+  initialConfig?: ProjectionConfig;
+}
+
+/**
+ * Componente raíz de la proyección de saldo. El usuario configura:
+ * - saldo inicial
+ * - fecha de inicio
+ * - horizonte de proyección ("a x tiempo")
+ * - reglas de ingreso/egreso (día de pago, monto, frecuencia)
+ *
+ * Y ve en tiempo real cómo cambia el saldo proyectado, incluyendo el
+ * punto más ajustado del período y la fórmula aplicada día a día.
+ */
+export function CashflowProjection({ initialConfig = DEFAULT_CONFIG }: CashflowProjectionProps) {
+  const [config, setConfig] = useState<ProjectionConfig>(initialConfig);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+
+  const { results, lowestBalanceDay, finalBalance } = useCashflowProjection(config);
+
+  const selectedIndex = results.findIndex((r) => r.date === selectedDate);
+  const selectedDay = selectedIndex >= 0 ? results[selectedIndex] : undefined;
+  const previousBalance =
+    selectedIndex > 0 ? results[selectedIndex - 1].balance : config.initialBalance;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Configuración de la proyección</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div>
+            <Label htmlFor="initial-balance">Saldo inicial</Label>
+            <Input
+              id="initial-balance"
+              type="number"
+              value={config.initialBalance}
+              onChange={(e) =>
+                setConfig({ ...config, initialBalance: Number(e.target.value) })
+              }
+            />
+          </div>
+          <div>
+            <Label htmlFor="start-date">Fecha de inicio</Label>
+            <Input
+              id="start-date"
+              type="date"
+              value={config.startDate}
+              onChange={(e) => setConfig({ ...config, startDate: e.target.value })}
+            />
+          </div>
+          <div>
+            <Label htmlFor="horizon">Días a proyectar</Label>
+            <Input
+              id="horizon"
+              type="number"
+              min={1}
+              max={730}
+              value={config.horizonDays}
+              onChange={(e) =>
+                setConfig({ ...config, horizonDays: Number(e.target.value) })
+              }
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <RuleEditor rules={config.rules} onChange={(rules) => setConfig({ ...config, rules })} />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Proyección de saldo</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <p className="text-muted-foreground">Saldo final proyectado</p>
+              <p className="text-lg font-semibold">${finalBalance.toLocaleString("es-CL")}</p>
+            </div>
+            {lowestBalanceDay && (
+              <div>
+                <p className="text-muted-foreground">Punto más ajustado</p>
+                <p
+                  className={`text-lg font-semibold ${
+                    lowestBalanceDay.balance < 0 ? "text-destructive" : ""
+                  }`}
+                >
+                  ${lowestBalanceDay.balance.toLocaleString("es-CL")}
+                  <span className="text-sm text-muted-foreground font-normal ml-2">
+                    ({lowestBalanceDay.date})
+                  </span>
+                </p>
+              </div>
+            )}
+          </div>
+
+          <ProjectionChart
+            results={results}
+            selectedDate={selectedDate}
+            onSelectDay={setSelectedDate}
+          />
+        </CardContent>
+      </Card>
+
+      <FormulaDisplay day={selectedDay} previousBalance={previousBalance} />
+    </div>
+  );
+}

--- a/components/cashflow-projection/projection-chart.tsx
+++ b/components/cashflow-projection/projection-chart.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+} from "recharts";
+import type { CashflowDayResult } from "@/lib/cashflow";
+
+interface ProjectionChartProps {
+  results: CashflowDayResult[];
+  selectedDate: string | null;
+  onSelectDay: (date: string) => void;
+}
+
+export function ProjectionChart({ results, selectedDate, onSelectDay }: ProjectionChartProps) {
+  const data = results.map((r) => ({
+    date: r.date,
+    saldo: r.balance,
+  }));
+
+  return (
+    <div className="h-64 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart
+          data={data}
+          onClick={(e) => {
+            const label = e?.activeLabel;
+            if (typeof label === "string") onSelectDay(label);
+          }}
+        >
+          <defs>
+            <linearGradient id="saldoFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="currentColor" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="currentColor" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={(d: string) => d.slice(8, 10)}
+            fontSize={12}
+          />
+          <YAxis
+            tickFormatter={(v: number) => `$${(v / 1000).toFixed(0)}k`}
+            fontSize={12}
+            width={50}
+          />
+          <ReferenceLine y={0} stroke="hsl(var(--destructive))" strokeDasharray="4 4" />
+          <Tooltip
+            formatter={(value: number) => [`$${value.toLocaleString("es-CL")}`, "Saldo"]}
+            labelFormatter={(label: string) => label}
+          />
+          <Area
+            type="monotone"
+            dataKey="saldo"
+            stroke="currentColor"
+            fill="url(#saldoFill)"
+            strokeWidth={2}
+            className="text-primary"
+            dot={(props) => {
+              const isSelected = props.payload.date === selectedDate;
+              return (
+                <circle
+                  key={props.payload.date}
+                  cx={props.cx}
+                  cy={props.cy}
+                  r={isSelected ? 5 : 2}
+                  fill={isSelected ? "hsl(var(--primary))" : "currentColor"}
+                  className="cursor-pointer text-primary"
+                />
+              );
+            }}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+      <p className="text-xs text-muted-foreground text-center mt-1">
+        Click en cualquier punto del gráfico para ver la fórmula de ese día
+      </p>
+    </div>
+  );
+}

--- a/components/cashflow-projection/rule-editor.tsx
+++ b/components/cashflow-projection/rule-editor.tsx
@@ -79,8 +79,11 @@ export function RuleEditor({ rules, onChange }: RuleEditorProps) {
         )}
 
         {rules.map((rule) => (
-          <div key={rule.id} className="grid grid-cols-12 gap-2 items-end border-b pb-4">
-            <div className="col-span-3">
+          <div
+            key={rule.id}
+            className="grid grid-cols-2 sm:grid-cols-12 gap-3 sm:items-end border-b pb-4"
+          >
+            <div className="col-span-2 sm:col-span-3">
               <Label htmlFor={`label-${rule.id}`}>Concepto</Label>
               <Input
                 id={`label-${rule.id}`}
@@ -90,7 +93,7 @@ export function RuleEditor({ rules, onChange }: RuleEditorProps) {
               />
             </div>
 
-            <div className="col-span-2">
+            <div className="col-span-1 sm:col-span-2">
               <Label htmlFor={`amount-${rule.id}`}>Monto</Label>
               <Input
                 id={`amount-${rule.id}`}
@@ -101,7 +104,7 @@ export function RuleEditor({ rules, onChange }: RuleEditorProps) {
               <p className="text-xs text-muted-foreground mt-1">+ ingreso / - egreso</p>
             </div>
 
-            <div className="col-span-3">
+            <div className="col-span-1 sm:col-span-3">
               <Label htmlFor={`freq-${rule.id}`}>Frecuencia</Label>
               <Select
                 value={rule.frequency}
@@ -132,7 +135,7 @@ export function RuleEditor({ rules, onChange }: RuleEditorProps) {
               </Select>
             </div>
 
-            <div className="col-span-3">
+            <div className="col-span-2 sm:col-span-3">
               {rule.frequency === "weekly" && (
                 <>
                   <Label htmlFor={`dow-${rule.id}`}>Día de la semana</Label>
@@ -188,11 +191,11 @@ export function RuleEditor({ rules, onChange }: RuleEditorProps) {
               )}
 
               {rule.frequency === "daily-weekday" && (
-                <p className="text-xs text-muted-foreground pt-6">Se aplica lunes a viernes</p>
+                <p className="text-xs text-muted-foreground sm:pt-6">Se aplica lunes a viernes</p>
               )}
             </div>
 
-            <div className="col-span-1 flex justify-end">
+            <div className="col-span-2 sm:col-span-1 flex justify-end">
               <Button
                 size="icon"
                 variant="ghost"

--- a/components/cashflow-projection/rule-editor.tsx
+++ b/components/cashflow-projection/rule-editor.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { v4 as uuidv4 } from "uuid";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Trash2, Plus } from "lucide-react";
+import type { RecurringRule, RuleFrequency } from "@/types/cashflow-projection";
+
+interface RuleEditorProps {
+  rules: RecurringRule[];
+  onChange: (rules: RecurringRule[]) => void;
+}
+
+const FREQUENCY_LABELS: Record<RuleFrequency, string> = {
+  "daily-weekday": "Diario (lu-vi)",
+  weekly: "Semanal",
+  monthly: "Mensual",
+  "every-n-days": "Cada N días",
+};
+
+const WEEKDAYS = [
+  { value: 0, label: "Domingo" },
+  { value: 1, label: "Lunes" },
+  { value: 2, label: "Martes" },
+  { value: 3, label: "Miércoles" },
+  { value: 4, label: "Jueves" },
+  { value: 5, label: "Viernes" },
+  { value: 6, label: "Sábado" },
+];
+
+function emptyRule(): RecurringRule {
+  return {
+    id: uuidv4(),
+    label: "",
+    amount: 0,
+    frequency: "monthly",
+    config: { dayOfMonth: 1 },
+    enabled: true,
+  };
+}
+
+export function RuleEditor({ rules, onChange }: RuleEditorProps) {
+  const updateRule = (id: string, patch: Partial<RecurringRule>) => {
+    onChange(rules.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+  };
+
+  const updateRuleConfig = (id: string, configPatch: RecurringRule["config"]) => {
+    onChange(
+      rules.map((r) => (r.id === id ? { ...r, config: { ...r.config, ...configPatch } } : r))
+    );
+  };
+
+  const addRule = () => onChange([...rules, emptyRule()]);
+  const removeRule = (id: string) => onChange(rules.filter((r) => r.id !== id));
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-base">Condiciones de ingreso y egreso</CardTitle>
+        <Button size="sm" variant="outline" onClick={addRule}>
+          <Plus className="h-4 w-4 mr-1" />
+          Agregar
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {rules.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            Sin reglas todavía. Agrega ingresos y egresos recurrentes para proyectar tu saldo.
+          </p>
+        )}
+
+        {rules.map((rule) => (
+          <div key={rule.id} className="grid grid-cols-12 gap-2 items-end border-b pb-4">
+            <div className="col-span-3">
+              <Label htmlFor={`label-${rule.id}`}>Concepto</Label>
+              <Input
+                id={`label-${rule.id}`}
+                value={rule.label}
+                placeholder="Arriendo, ingreso, etc."
+                onChange={(e) => updateRule(rule.id, { label: e.target.value })}
+              />
+            </div>
+
+            <div className="col-span-2">
+              <Label htmlFor={`amount-${rule.id}`}>Monto</Label>
+              <Input
+                id={`amount-${rule.id}`}
+                type="number"
+                value={rule.amount}
+                onChange={(e) => updateRule(rule.id, { amount: Number(e.target.value) })}
+              />
+              <p className="text-xs text-muted-foreground mt-1">+ ingreso / - egreso</p>
+            </div>
+
+            <div className="col-span-3">
+              <Label htmlFor={`freq-${rule.id}`}>Frecuencia</Label>
+              <Select
+                value={rule.frequency}
+                onValueChange={(value: RuleFrequency) =>
+                  updateRule(rule.id, {
+                    frequency: value,
+                    config:
+                      value === "weekly"
+                        ? { dayOfWeek: 0 }
+                        : value === "monthly"
+                          ? { dayOfMonth: 1 }
+                          : value === "every-n-days"
+                            ? { interval: 30 }
+                            : {},
+                  })
+                }
+              >
+                <SelectTrigger id={`freq-${rule.id}`}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(FREQUENCY_LABELS).map(([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="col-span-3">
+              {rule.frequency === "weekly" && (
+                <>
+                  <Label htmlFor={`dow-${rule.id}`}>Día de la semana</Label>
+                  <Select
+                    value={String(rule.config.dayOfWeek ?? 0)}
+                    onValueChange={(value) =>
+                      updateRuleConfig(rule.id, { dayOfWeek: Number(value) })
+                    }
+                  >
+                    <SelectTrigger id={`dow-${rule.id}`}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {WEEKDAYS.map((d) => (
+                        <SelectItem key={d.value} value={String(d.value)}>
+                          {d.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </>
+              )}
+
+              {rule.frequency === "monthly" && (
+                <>
+                  <Label htmlFor={`dom-${rule.id}`}>Día del mes</Label>
+                  <Input
+                    id={`dom-${rule.id}`}
+                    type="number"
+                    min={1}
+                    max={31}
+                    value={rule.config.dayOfMonth ?? 1}
+                    onChange={(e) =>
+                      updateRuleConfig(rule.id, { dayOfMonth: Number(e.target.value) })
+                    }
+                  />
+                </>
+              )}
+
+              {rule.frequency === "every-n-days" && (
+                <>
+                  <Label htmlFor={`interval-${rule.id}`}>Cada cuántos días</Label>
+                  <Input
+                    id={`interval-${rule.id}`}
+                    type="number"
+                    min={1}
+                    value={rule.config.interval ?? 1}
+                    onChange={(e) =>
+                      updateRuleConfig(rule.id, { interval: Number(e.target.value) })
+                    }
+                  />
+                </>
+              )}
+
+              {rule.frequency === "daily-weekday" && (
+                <p className="text-xs text-muted-foreground pt-6">Se aplica lunes a viernes</p>
+              )}
+            </div>
+
+            <div className="col-span-1 flex justify-end">
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={() => removeRule(rule.id)}
+                aria-label="Eliminar regla"
+              >
+                <Trash2 className="h-4 w-4 text-destructive" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/docs/cashflow-projection.md
+++ b/docs/cashflow-projection.md
@@ -1,0 +1,108 @@
+# 📈 Proyección de saldo (cashflow-projection)
+
+Componente y motor de proyección de saldo a futuro, configurable por el
+usuario: define reglas de ingreso/egreso recurrentes (día de pago, monto,
+frecuencia) y visualiza cómo evoluciona el saldo a lo largo del tiempo,
+incluyendo el punto más ajustado del período.
+
+Construido sobre la utilidad base [`lib/cashflow.ts`](./cashflow.md) — no
+la reemplaza, la extiende.
+
+## Diferencia con `lib/cashflow.ts`
+
+| | `lib/cashflow.ts` | `lib/cashflow-projection.ts` |
+|---|---|---|
+| Entrada | Lista fija de días con movimientos ya definidos | Reglas recurrentes + horizonte de tiempo |
+| Uso típico | Un mes ya conocido, con montos y fechas específicas | Proyección configurable, horizonte variable, editable en UI |
+| Relación | Motor de cálculo base | Genera el input para `calculateDailyBalance` |
+
+## Estructura de archivos
+
+```
+types/cashflow-projection.ts       # RecurringRule, ProjectionConfig
+lib/cashflow-projection.ts         # expandRulesToDays, projectCashflow
+hooks/use-cashflow-projection.ts   # useCashflowProjection (memoización)
+components/cashflow-projection/
+  index.tsx                        # componente raíz, arma todo
+  rule-editor.tsx                  # form para agregar/editar reglas
+  projection-chart.tsx             # gráfico de saldo (recharts)
+  formula-display.tsx              # fórmula con valores reales del día
+```
+
+## Modelo de datos
+
+Una `RecurringRule` representa un ingreso o egreso que se repite:
+
+```ts
+{
+  id: "uuid",
+  label: "Arriendo",
+  amount: -20000,        // negativo = egreso, positivo = ingreso
+  frequency: "monthly",
+  config: { dayOfMonth: 20 }
+}
+```
+
+Frecuencias soportadas: `daily-weekday` (lu-vi), `weekly` (día fijo de
+semana), `monthly` (día fijo del mes), `every-n-days` (cada N días desde
+`startDate`).
+
+## Cómo se calcula
+
+1. `expandRulesToDays(config)` recorre cada día del horizonte y evalúa qué
+   reglas aplican ese día (`ruleAppliesOnDate`), generando un
+   `CashflowDayInput[]`.
+2. Ese resultado se pasa a `calculateDailyBalance` (de `lib/cashflow.ts`),
+   que aplica la fórmula ya documentada:
+   ```
+   saldo(día n) = saldo(día n-1) + ingresos(día n) - egresos(día n)
+   ```
+3. `projectCashflow(config)` encadena ambos pasos — es el único punto de
+   entrada que necesitan los componentes.
+
+## Uso
+
+```tsx
+import { CashflowProjection } from "@/components/cashflow-projection";
+
+<CashflowProjection
+  initialConfig={{
+    initialBalance: 30000,
+    startDate: "2026-08-01",
+    horizonDays: 90,
+    rules: [
+      { id: "1", label: "Ingreso diario", amount: 10000, frequency: "daily-weekday", config: {} },
+      { id: "2", label: "Transporte", amount: -10000, frequency: "weekly", config: { dayOfWeek: 0 } },
+      { id: "3", label: "Arriendo", amount: -20000, frequency: "monthly", config: { dayOfMonth: 20 } },
+    ],
+  }}
+/>
+```
+
+El usuario puede modificar cualquier condición (monto, día de pago,
+frecuencia, saldo inicial, horizonte) desde la UI — el gráfico y la
+fórmula se recalculan automáticamente vía `useMemo` en
+`useCashflowProjection`, sin necesidad de sincronización manual de estado.
+
+## Visualización de la fórmula
+
+Al hacer click en cualquier punto del gráfico, `FormulaDisplay` muestra la
+fórmula de saldo con los valores reales sustituidos para ese día
+específico, no una fórmula abstracta:
+
+```
+saldo(2026-08-12) = 30.300 - 20.000 = $20.300 ⚠️ Punto ajustado
+```
+
+## Dependencias
+
+Usa librerías ya presentes en el proyecto — no se agregó nada nuevo:
+`recharts` (gráfico), `uuid` (ids de reglas), componentes de
+`components/ui/*` (Radix UI ya instalado).
+
+## Changelog
+
+- **2026-08-12** — Se agrega el motor de proyección completo: tipos, motor
+  de expansión de reglas, hook de memoización y los cuatro componentes de
+  UI (`RuleEditor`, `ProjectionChart`, `FormulaDisplay`,
+  `CashflowProjection`).

--- a/hooks/use-cashflow-projection.ts
+++ b/hooks/use-cashflow-projection.ts
@@ -1,0 +1,23 @@
+/**
+ * hooks/use-cashflow-projection.ts
+ *
+ * Recalcula la proyección de saldo cada vez que cambia la configuración
+ * (reglas, saldo inicial, horizonte). El componente solo necesita mutar
+ * `config` con setState; el hook se encarga de recalcular vía useMemo.
+ */
+
+"use client";
+
+import { useMemo } from "react";
+import { projectCashflow, findLowestBalanceDay } from "@/lib/cashflow-projection";
+import type { ProjectionConfig } from "@/types/cashflow-projection";
+
+export function useCashflowProjection(config: ProjectionConfig) {
+  const results = useMemo(() => projectCashflow(config), [config]);
+
+  const lowestBalanceDay = useMemo(() => findLowestBalanceDay(results), [results]);
+
+  const finalBalance = results.at(-1)?.balance ?? config.initialBalance;
+
+  return { results, lowestBalanceDay, finalBalance };
+}

--- a/lib/cashflow-projection.ts
+++ b/lib/cashflow-projection.ts
@@ -1,0 +1,76 @@
+/**
+ * lib/cashflow-projection.ts
+ *
+ * Motor de proyección: expande reglas recurrentes (RecurringRule) en una
+ * lista de días (CashflowDayInput) para un horizonte de tiempo dado, y
+ * reutiliza calculateDailyBalance de lib/cashflow.ts para el cálculo real
+ * de saldo. No duplica esa lógica, solo la alimenta con datos generados.
+ */
+
+import { calculateDailyBalance, type CashflowDayInput, type CashflowDayResult } from "./cashflow";
+import type { ProjectionConfig, RecurringRule } from "@/types/cashflow-projection";
+
+/** Determina si una regla aplica en una fecha específica */
+export function ruleAppliesOnDate(rule: RecurringRule, date: Date, startDate: Date): boolean {
+  if (rule.enabled === false) return false;
+
+  switch (rule.frequency) {
+    case "daily-weekday": {
+      const day = date.getDay();
+      return day >= 1 && day <= 5; // lunes(1) a viernes(5)
+    }
+    case "weekly": {
+      return date.getDay() === rule.config.dayOfWeek;
+    }
+    case "monthly": {
+      return date.getDate() === rule.config.dayOfMonth;
+    }
+    case "every-n-days": {
+      const interval = rule.config.interval ?? 1;
+      const diffDays = Math.round(
+        (date.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)
+      );
+      return diffDays >= 0 && diffDays % interval === 0;
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * Expande las reglas recurrentes de una configuración en una lista de días
+ * con sus movimientos correspondientes, lista para pasarle a
+ * calculateDailyBalance.
+ */
+export function expandRulesToDays(config: ProjectionConfig): CashflowDayInput[] {
+  const start = new Date(`${config.startDate}T00:00:00`);
+  const days: CashflowDayInput[] = [];
+
+  for (let i = 0; i < config.horizonDays; i++) {
+    const date = new Date(start);
+    date.setDate(start.getDate() + i);
+
+    const movements = config.rules
+      .filter((rule) => ruleAppliesOnDate(rule, date, start))
+      .map((rule) => ({ label: rule.label, amount: rule.amount }));
+
+    days.push({ date: date.toISOString().slice(0, 10), movements });
+  }
+
+  return days;
+}
+
+/**
+ * Corre la proyección completa: expande las reglas y calcula el saldo
+ * acumulado día a día. Punto de entrada único para los componentes/hooks.
+ */
+export function projectCashflow(config: ProjectionConfig): CashflowDayResult[] {
+  const days = expandRulesToDays(config);
+  return calculateDailyBalance(config.initialBalance, days);
+}
+
+/** Encuentra el día con el saldo más bajo de una proyección (el "punto crítico") */
+export function findLowestBalanceDay(results: CashflowDayResult[]): CashflowDayResult | undefined {
+  if (results.length === 0) return undefined;
+  return results.reduce((lowest, current) => (current.balance < lowest.balance ? current : lowest));
+}

--- a/types/cashflow-projection.ts
+++ b/types/cashflow-projection.ts
@@ -1,0 +1,52 @@
+/**
+ * types/cashflow-projection.ts
+ *
+ * Tipos para el motor de proyección de saldo: en vez de guardar días fijos
+ * (como en lib/cashflow.ts), se guardan reglas recurrentes que se expanden
+ * dinámicamente sobre un horizonte de tiempo configurable.
+ */
+
+/** Frecuencia con la que se aplica una regla recurrente */
+export type RuleFrequency =
+  | "daily-weekday" // lunes a viernes
+  | "weekly" // un día fijo de la semana
+  | "monthly" // un día fijo del mes
+  | "every-n-days"; // cada N días desde la fecha de inicio
+
+/** Configuración específica según el tipo de frecuencia */
+export interface RuleFrequencyConfig {
+  /** Día de la semana (0 = domingo ... 6 = sábado), usado con "weekly" */
+  dayOfWeek?: number;
+  /** Día del mes (1-31), usado con "monthly" */
+  dayOfMonth?: number;
+  /** Intervalo en días, usado con "every-n-days" */
+  interval?: number;
+}
+
+/**
+ * Una regla recurrente configurable por el usuario: representa un ingreso
+ * o egreso que se repite según una frecuencia (ej. "arriendo, $20.000,
+ * mensual, día 20").
+ */
+export interface RecurringRule {
+  id: string;
+  label: string;
+  /** Monto: positivo = ingreso, negativo = egreso */
+  amount: number;
+  frequency: RuleFrequency;
+  config: RuleFrequencyConfig;
+  /** Si es false, la regla se ignora al proyectar (sin borrarla) */
+  enabled?: boolean;
+}
+
+/** Configuración completa de una proyección de saldo */
+export interface ProjectionConfig {
+  /** Saldo con el que se parte */
+  initialBalance: number;
+  /** Fecha de inicio de la proyección, formato ISO (YYYY-MM-DD) */
+  startDate: string;
+  /** Cuántos días hacia adelante proyectar ("a x tiempo") */
+  horizonDays: number;
+  /** Reglas recurrentes que generan los movimientos día a día */
+  rules: RecurringRule[];
+}


### PR DESCRIPTION
## Qué hace

Motor de proyección de saldo configurable por el usuario, construido sobre
`lib/cashflow.ts` (no lo reemplaza, lo extiende).

En vez de datos fijos día por día, el usuario define **reglas recurrentes**
(concepto, monto, frecuencia, día de pago) y el sistema proyecta el saldo
a futuro sobre un horizonte de tiempo configurable ("a x tiempo").

## Piezas nuevas

- `types/cashflow-projection.ts` — `RecurringRule`, `ProjectionConfig`
- `lib/cashflow-projection.ts` — `expandRulesToDays`, `projectCashflow`, `findLowestBalanceDay`
- `hooks/use-cashflow-projection.ts` — memoización reactiva del cálculo
- `components/cashflow-projection/`
  - `rule-editor.tsx` — form para agregar/editar/eliminar reglas
  - `projection-chart.tsx` — gráfico interactivo (recharts, ya en el proyecto)
  - `formula-display.tsx` — muestra la fórmula de saldo con valores reales sustituidos, para el día seleccionado en el gráfico
  - `index.tsx` — componente raíz que arma todo

## Cómo se calcula

```
saldo(día n) = saldo(día n-1) + ingresos(día n) - egresos(día n)
```

Misma fórmula que `lib/cashflow.ts` — este PR solo agrega la capa que
genera los días dinámicamente a partir de reglas, en vez de requerir la
lista completa hardcodeada.

## Notas

- Sin dependencias nuevas — usa `recharts`, `uuid` y componentes de `components/ui/*` ya presentes en el proyecto.
- Documentado en `docs/cashflow-projection.md`, referenciado desde el README (mismo patrón que `docs/cashflow.md`).
- CHANGELOG actualizado bajo `[Unreleased]`.

## Pendiente / fuera de alcance de este PR

- No incluye persistencia (guardar reglas en Supabase) — por ahora vive en estado local del componente vía `useState`.
- No incluye tests — si quieres que agregue cobertura con Vitest antes de mergear, avísame.
