### PR TITLE
Improve mobile transaction history readability

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -21,7 +21,7 @@ interface NavbarProps {
   deleteAccount: (accountId: string) => boolean
   addTransaction: (transaction: Omit<Transaction, 'id'>) => void
   updateTransaction: (transaction: Transaction) => void
-  removeTransaction: (transactionId: string) => void
+  removeTransaction: (transactionId: string, refund?: boolean) => void
   transferFunds: (transfer: {
     amount: Int
     fromAccount: string
@@ -39,6 +39,7 @@ export default function Navbar({
   deleteAccount,
   addTransaction,
   updateTransaction,
+  removeTransaction,
   transferFunds
 }: NavbarProps) {
   const [isTransactionModalOpen, setIsTransactionModalOpen] = useState(false)
@@ -120,7 +121,11 @@ export default function Navbar({
           className="mt-6"
         >
           <ErrorBoundary>
-            <TransactionHistory transactions={transactions} />
+            <TransactionHistory
+              accounts={accounts}
+              transactions={transactions}
+              removeTransaction={removeTransaction}
+            />
           </ErrorBoundary>
         </TabsContent>
       </Tabs>

--- a/components/transaction-history.tsx
+++ b/components/transaction-history.tsx
@@ -41,47 +41,106 @@ export function TransactionHistory({ transactions }: { transactions: Transaction
         {transactions.length === 0 ? (
           <p className="text-center text-muted-foreground py-4">{t("noTransactions")}</p>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>{t("date")}</TableHead>
-                <TableHead>{t("description")}</TableHead>
-                <TableHead>{t("account")}</TableHead>
-                <TableHead className="text-right">{t("amount")}</TableHead>
-                <TableHead className="w-10"></TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
+          <>
+            <div className="hidden md:block">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t("date")}</TableHead>
+                    <TableHead>{t("description")}</TableHead>
+                    <TableHead>{t("account")}</TableHead>
+                    <TableHead className="text-right">{t("amount")}</TableHead>
+                    <TableHead className="w-10"></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {transactions.map((transaction: Transaction) => {
+                    const account = accounts.find((acc) => acc.id === transaction.account)
+                    const accountName = account?.name || t("unknownAccount")
+                    const description = transaction.description || "—"
+
+                    return (
+                      <TableRow key={transaction.id}>
+                        <TableCell>{format(new Date(transaction.date), "d MMM yyyy", { locale })}</TableCell>
+                        <TableCell>{description}</TableCell>
+                        <TableCell className="capitalize">{accountName}</TableCell>
+                        <TableCell className={`text-right ${transaction.amount < 0 ? "text-red-500" : ""}`}>
+                          {formatCurrency(Math.abs(transaction.amount))}
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                            aria-label={`${t("delete")}: ${description}`}
+                            title={`${t("delete")}: ${description}`}
+                            onClick={() =>
+                              setDeleteTarget({
+                                transaction,
+                                accountName
+                              })
+                            }
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="space-y-3 md:hidden">
               {transactions.map((transaction: Transaction) => {
                 const account = accounts.find((acc) => acc.id === transaction.account)
+                const accountName = account?.name || t("unknownAccount")
+                const description = transaction.description || "—"
+
                 return (
-                  <TableRow key={transaction.id}>
-                    <TableCell>{format(new Date(transaction.date), "d MMM yyyy", { locale })}</TableCell>
-                    <TableCell>{transaction.description || "—"}</TableCell>
-                    <TableCell className="capitalize">{account ? account.name : t("unknownAccount")}</TableCell>
-                    <TableCell className={`text-right ${transaction.amount < 0 ? "text-red-500" : ""}`}>
-                      {formatCurrency(Math.abs(transaction.amount))}
-                    </TableCell>
-                    <TableCell>
+                  <article
+                    key={transaction.id}
+                    className="rounded-lg border bg-card p-3 shadow-sm"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <p className="break-words font-medium leading-5">{description}</p>
+                        <div className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                          <time dateTime={new Date(transaction.date).toISOString()}>
+                            {format(new Date(transaction.date), "d MMM yyyy", { locale })}
+                          </time>
+                          <span aria-hidden="true">•</span>
+                          <span className="capitalize break-words">{accountName}</span>
+                        </div>
+                      </div>
+                      <p className={`shrink-0 text-right font-semibold ${transaction.amount < 0 ? "text-red-500" : ""}`}>
+                        {formatCurrency(Math.abs(transaction.amount))}
+                      </p>
+                    </div>
+
+                    <div className="mt-3 flex justify-end border-t pt-2">
                       <Button
                         variant="ghost"
-                        size="icon"
-                        className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                        size="sm"
+                        className="h-8 px-2 text-muted-foreground hover:text-destructive"
+                        aria-label={`${t("delete")}: ${description}`}
+                        title={`${t("delete")}: ${description}`}
                         onClick={() =>
                           setDeleteTarget({
                             transaction,
-                            accountName: account?.name || t("unknownAccount")
+                            accountName
                           })
                         }
                       >
-                        <Trash2 className="h-3.5 w-3.5" />
+                        <Trash2 className="mr-2 h-3.5 w-3.5" />
+                        {t("delete")}
                       </Button>
-                    </TableCell>
-                  </TableRow>
+                    </div>
+                  </article>
                 )
               })}
-            </TableBody>
-          </Table>
+            </div>
+          </>
         )}
       </CardContent>
 

--- a/components/transaction-history.tsx
+++ b/components/transaction-history.tsx
@@ -9,14 +9,22 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Button } from "@/components/ui/button"
 import { useLanguage } from "@/contexts/language-context"
 import { useCurrency } from "@/contexts/currency-context"
-import { useBudget } from "@/hooks/use-budget"
-import { Transaction } from '@/types'
+import { Account, Transaction } from '@/types'
 import { DeleteTransactionModal } from "@/components/modals/delete-transaction-modal"
 
-export function TransactionHistory({ transactions }: { transactions: Transaction[] }) {
+interface TransactionHistoryProps {
+  accounts: Account[]
+  transactions: Transaction[]
+  removeTransaction: (transactionId: string, refund?: boolean) => void
+}
+
+export function TransactionHistory({
+  accounts,
+  transactions,
+  removeTransaction
+}: TransactionHistoryProps) {
   const { t, language } = useLanguage()
   const { formatCurrency } = useCurrency()
-  const { accounts, removeTransaction } = useBudget()
   const [deleteTarget, setDeleteTarget] = useState<{
     transaction: Transaction
     accountName: string
@@ -24,6 +32,11 @@ export function TransactionHistory({ transactions }: { transactions: Transaction
 
   // Set locale based on language
   const locale = language === "es" ? es : undefined
+  const formatTransactionDate = (date: Date | string) => {
+    const formattedDate = format(new Date(date), "d MMM", { locale }).replace(/\./g, "")
+    const [day, month] = formattedDate.split(" ")
+    return `${day} ${month.slice(0, 3)}`
+  }
 
   const handleDelete = (refund: boolean) => {
     if (!deleteTarget) return
@@ -61,7 +74,7 @@ export function TransactionHistory({ transactions }: { transactions: Transaction
 
                     return (
                       <TableRow key={transaction.id}>
-                        <TableCell>{format(new Date(transaction.date), "d MMM yyyy", { locale })}</TableCell>
+                        <TableCell>{formatTransactionDate(transaction.date)}</TableCell>
                         <TableCell>{description}</TableCell>
                         <TableCell className="capitalize">{accountName}</TableCell>
                         <TableCell className={`text-right ${transaction.amount < 0 ? "text-red-500" : ""}`}>
@@ -107,7 +120,7 @@ export function TransactionHistory({ transactions }: { transactions: Transaction
                         <p className="break-words font-medium leading-5">{description}</p>
                         <div className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-xs text-muted-foreground">
                           <time dateTime={new Date(transaction.date).toISOString()}>
-                            {format(new Date(transaction.date), "d MMM yyyy", { locale })}
+                            {formatTransactionDate(transaction.date)}
                           </time>
                           <span aria-hidden="true">•</span>
                           <span className="capitalize break-words">{accountName}</span>
@@ -121,8 +134,8 @@ export function TransactionHistory({ transactions }: { transactions: Transaction
                     <div className="mt-3 flex justify-end border-t pt-2">
                       <Button
                         variant="ghost"
-                        size="sm"
-                        className="h-8 px-2 text-muted-foreground hover:text-destructive"
+                        size="icon"
+                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
                         aria-label={`${t("delete")}: ${description}`}
                         title={`${t("delete")}: ${description}`}
                         onClick={() =>
@@ -132,8 +145,7 @@ export function TransactionHistory({ transactions }: { transactions: Transaction
                           })
                         }
                       >
-                        <Trash2 className="mr-2 h-3.5 w-3.5" />
-                        {t("delete")}
+                        <Trash2 className="h-3.5 w-3.5" />
                       </Button>
                     </div>
                   </article>


### PR DESCRIPTION
## Summary
- Keep the transaction table for desktop layouts and use readable cards on mobile.
- Show transaction dates as day plus a three-letter month abbreviation, without the year.
- Keep the mobile delete action icon-only while preserving its accessible label and tooltip.
- Pass the shared account state and remove function into transaction history so deleting a movement updates the real budget state.

## Validation
- `git diff --check` passed.
- Next.js compiled the changed code successfully.
- The full build could not complete because the package firewall blocked the existing Vitest package while Next.js attempted to install missing TypeScript development dependencies.
