### PR TITLE
feat: ordenar y agrupar historial de movimientos por fecha

### DIFF
--- a/components/transaction-history.tsx
+++ b/components/transaction-history.tsx
@@ -39,10 +39,10 @@ export function TransactionHistory({
   // Set locale based on language
   const locale = language === "es" ? es : undefined
 
-  // Oldest -> newest, grouped by calendar day
+  // Newest -> oldest, grouped by calendar day
   const groupedTransactions = useMemo<TransactionGroup[]>(() => {
     const sorted = [...transactions].sort(
-      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
     )
 
     const groups: TransactionGroup[] = []

--- a/components/transaction-history.tsx
+++ b/components/transaction-history.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { Fragment, useMemo, useState } from "react"
 import { format } from "date-fns"
 import { es } from "date-fns/locale/es"
 import { Trash2 } from "lucide-react"
@@ -18,6 +18,12 @@ interface TransactionHistoryProps {
   removeTransaction: (transactionId: string, refund?: boolean) => void
 }
 
+interface TransactionGroup {
+  dateKey: string
+  dateLabel: string
+  items: Transaction[]
+}
+
 export function TransactionHistory({
   accounts,
   transactions,
@@ -32,11 +38,30 @@ export function TransactionHistory({
 
   // Set locale based on language
   const locale = language === "es" ? es : undefined
-  const formatTransactionDate = (date: Date | string) => {
-    const formattedDate = format(new Date(date), "d MMM", { locale }).replace(/\./g, "")
-    const [day, month] = formattedDate.split(" ")
-    return `${day} ${month.slice(0, 3)}`
-  }
+
+  // Oldest -> newest, grouped by calendar day
+  const groupedTransactions = useMemo<TransactionGroup[]>(() => {
+    const sorted = [...transactions].sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+    )
+
+    const groups: TransactionGroup[] = []
+
+    for (const transaction of sorted) {
+      const date = new Date(transaction.date)
+      const dateKey = format(date, "yyyy-MM-dd")
+      const dateLabel = format(date, "d 'de' MMMM, yyyy", { locale })
+
+      const lastGroup = groups[groups.length - 1]
+      if (lastGroup && lastGroup.dateKey === dateKey) {
+        lastGroup.items.push(transaction)
+      } else {
+        groups.push({ dateKey, dateLabel, items: [transaction] })
+      }
+    }
+
+    return groups
+  }, [transactions, locale])
 
   const handleDelete = (refund: boolean) => {
     if (!deleteTarget) return
@@ -59,7 +84,6 @@ export function TransactionHistory({
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>{t("date")}</TableHead>
                     <TableHead>{t("description")}</TableHead>
                     <TableHead>{t("account")}</TableHead>
                     <TableHead className="text-right">{t("amount")}</TableHead>
@@ -67,90 +91,106 @@ export function TransactionHistory({
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {transactions.map((transaction: Transaction) => {
-                    const account = accounts.find((acc) => acc.id === transaction.account)
-                    const accountName = account?.name || t("unknownAccount")
-                    const description = transaction.description || "—"
-
-                    return (
-                      <TableRow key={transaction.id}>
-                        <TableCell>{formatTransactionDate(transaction.date)}</TableCell>
-                        <TableCell>{description}</TableCell>
-                        <TableCell className="capitalize">{accountName}</TableCell>
-                        <TableCell className={`text-right ${transaction.amount < 0 ? "text-red-500" : ""}`}>
-                          {formatCurrency(Math.abs(transaction.amount))}
-                        </TableCell>
-                        <TableCell>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7 text-muted-foreground hover:text-destructive"
-                            aria-label={`${t("delete")}: ${description}`}
-                            title={`${t("delete")}: ${description}`}
-                            onClick={() =>
-                              setDeleteTarget({
-                                transaction,
-                                accountName
-                              })
-                            }
-                          >
-                            <Trash2 className="h-3.5 w-3.5" />
-                          </Button>
+                  {groupedTransactions.map((group) => (
+                    <Fragment key={group.dateKey}>
+                      <TableRow className="hover:bg-transparent">
+                        <TableCell
+                          colSpan={4}
+                          className="bg-muted/50 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground capitalize"
+                        >
+                          {group.dateLabel}
                         </TableCell>
                       </TableRow>
-                    )
-                  })}
+                      {group.items.map((transaction) => {
+                        const account = accounts.find((acc) => acc.id === transaction.account)
+                        const accountName = account?.name || t("unknownAccount")
+                        const description = transaction.description || "—"
+
+                        return (
+                          <TableRow key={transaction.id}>
+                            <TableCell>{description}</TableCell>
+                            <TableCell className="capitalize">{accountName}</TableCell>
+                            <TableCell className={`text-right ${transaction.amount < 0 ? "text-red-500" : ""}`}>
+                              {formatCurrency(Math.abs(transaction.amount))}
+                            </TableCell>
+                            <TableCell>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                                aria-label={`${t("delete")}: ${description}`}
+                                title={`${t("delete")}: ${description}`}
+                                onClick={() =>
+                                  setDeleteTarget({
+                                    transaction,
+                                    accountName
+                                  })
+                                }
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </TableCell>
+                          </TableRow>
+                        )
+                      })}
+                    </Fragment>
+                  ))}
                 </TableBody>
               </Table>
             </div>
 
-            <div className="space-y-3 md:hidden">
-              {transactions.map((transaction: Transaction) => {
-                const account = accounts.find((acc) => acc.id === transaction.account)
-                const accountName = account?.name || t("unknownAccount")
-                const description = transaction.description || "—"
+            <div className="space-y-4 md:hidden">
+              {groupedTransactions.map((group) => (
+                <div key={group.dateKey} className="space-y-2">
+                  <h3 className="px-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground capitalize">
+                    {group.dateLabel}
+                  </h3>
+                  <div className="space-y-3">
+                    {group.items.map((transaction) => {
+                      const account = accounts.find((acc) => acc.id === transaction.account)
+                      const accountName = account?.name || t("unknownAccount")
+                      const description = transaction.description || "—"
 
-                return (
-                  <article
-                    key={transaction.id}
-                    className="rounded-lg border bg-card p-3 shadow-sm"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0 flex-1">
-                        <p className="break-words font-medium leading-5">{description}</p>
-                        <div className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-xs text-muted-foreground">
-                          <time dateTime={new Date(transaction.date).toISOString()}>
-                            {formatTransactionDate(transaction.date)}
-                          </time>
-                          <span aria-hidden="true">•</span>
-                          <span className="capitalize break-words">{accountName}</span>
-                        </div>
-                      </div>
-                      <p className={`shrink-0 text-right font-semibold ${transaction.amount < 0 ? "text-red-500" : ""}`}>
-                        {formatCurrency(Math.abs(transaction.amount))}
-                      </p>
-                    </div>
+                      return (
+                        <article
+                          key={transaction.id}
+                          className="rounded-lg border bg-card p-3 shadow-sm"
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0 flex-1">
+                              <p className="break-words font-medium leading-5">{description}</p>
+                              <div className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                                <span className="capitalize break-words">{accountName}</span>
+                              </div>
+                            </div>
+                            <p className={`shrink-0 text-right font-semibold ${transaction.amount < 0 ? "text-red-500" : ""}`}>
+                              {formatCurrency(Math.abs(transaction.amount))}
+                            </p>
+                          </div>
 
-                    <div className="mt-3 flex justify-end border-t pt-2">
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 text-muted-foreground hover:text-destructive"
-                        aria-label={`${t("delete")}: ${description}`}
-                        title={`${t("delete")}: ${description}`}
-                        onClick={() =>
-                          setDeleteTarget({
-                            transaction,
-                            accountName
-                          })
-                        }
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                  </article>
-                )
-              })}
+                          <div className="mt-3 flex justify-end border-t pt-2">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                              aria-label={`${t("delete")}: ${description}`}
+                              title={`${t("delete")}: ${description}`}
+                              onClick={() =>
+                                setDeleteTarget({
+                                  transaction,
+                                  accountName
+                                })
+                              }
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </div>
+                        </article>
+                      )
+                    })}
+                  </div>
+                </div>
+              ))}
             </div>
           </>
         )}


### PR DESCRIPTION
## Qué hace
`components/transaction-history.tsx` ahora:
- Ordena las transacciones de más reciente a más antigua (antes se renderizaban en el orden recibido, sin ordenar)
- Las agrupa por día calendario, con un encabezado de fecha por grupo (tabla desktop y tarjetas mobile)

## Detalle
- Se quitó la columna "Fecha" por fila (ahora vive en el encabezado del grupo)
- El agrupamiento usa 'date-fns format(date, "yyyy-MM-dd")' como clave de grupo, respetando el locale actual (es/en) para la etiqueta visible
- Sin cambios de tipos ni de props del componente

Listo para merge manual.